### PR TITLE
Redesign fixes

### DIFF
--- a/redesign/background.js
+++ b/redesign/background.js
@@ -32,9 +32,13 @@ chrome.action.onClicked.addListener(async (tab) => {
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === 'archivebox_add') {
-    const response = fetch(`${message.url}/api/v1/cli/add`, {
+    const { archivebox_server_url, archivebox_api_key } = await chrome.storage.local.get([
+        'archivebox_server_url',
+        'archivebox_api_key'
+    ]);
+    const response = fetch(`${archivebox_server_url}/api/v1/cli/add`, {
       headers: new Headers({
-        "x-archivebox-api-key": `${message.apiKey}`
+        "x-archivebox-api-key": `${archivebox_api_key}`
       }),
       method: "post",
       credentials: "include",

--- a/redesign/background.js
+++ b/redesign/background.js
@@ -32,7 +32,10 @@ chrome.action.onClicked.addListener(async (tab) => {
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === 'archivebox_add') {
-    fetch(`${message.url}/add/`, {
+    const response = fetch(`${message.url}/api/v1/cli/add`, {
+      headers: new Headers({
+        "x-archivebox-api-key": `${message.apiKey}`
+      }),
       method: "post",
       credentials: "include",
       body: message.body

--- a/redesign/background.js
+++ b/redesign/background.js
@@ -29,3 +29,16 @@ chrome.action.onClicked.addListener(async (tab) => {
     files: ['popup.js']
   });
 });
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'archivebox_add') {
+    fetch(`${message.url}/add/`, {
+      method: "post",
+      credentials: "include",
+      body: message.body
+    })
+    .then(response => sendResponse(response))
+    .catch(error => sendResponse({error: error.message}));
+    return true; // Required for async response
+  }
+});

--- a/redesign/manifest.json
+++ b/redesign/manifest.json
@@ -23,11 +23,6 @@
       "128": "icons/128.png"
     }
   },
-  "content_scripts": [{
-    "matches": ["<all_urls>"],
-    "js": ["content-script.js"],
-    "run_at": "document_idle"
-  }],
   "options_page": "options.html",
   "background": {
     "service_worker": "background.js"

--- a/redesign/popup.js
+++ b/redesign/popup.js
@@ -20,70 +20,31 @@ async function sendToArchiveBox(url, tags) {
 
   try {
     console.log('i Sending to ArchiveBox', { endpoint: `${archivebox_server_url}/api/v1/cli/add`, method: 'POST', url, tags });
-    const response = await fetch(`${archivebox_server_url}/api/v1/cli/add`, {
-      method: 'POST', 
-      mode: 'no-cors',
-      credentials: 'omit',
-      body: JSON.stringify({
-        api_key: archivebox_api_key,
-        urls: [url],
-        tag: tags.join(','),
-        depth: 0,
-        update: false,
-        update_all: false,
-      }),
+
+    const body = JSON.stringify({
+      "urls": [url],
+      "tag": tags.join(","),
+      "depth": 0,
+      "update": false,
+      "update_all": false,
+      "index_only": false,
+      "overwrite": false,
+      "init": false,
+      "extractors": "",
+      "parser": "auto"
+    })
+
+    const response = chrome.runtime.sendMessage({
+      type: 'archivebox_add',
+      url: archivebox_server_url,
+      apiKey: archivebox_api_key,
+      body: body
     });
 
-    // TODO: Replace
-    // const response = await fetch(`${archivebox_server_url}/api/v1/cli/add`, {
-    //   method: "POST",
-    //   mode: "no-cors",
-    //   credentials: "omit",
-    //   body: JSON.stringify({
-    //     api_key: archivebox_api_key,
-    //     urls: [url],
-    //     tag: tags.join(","),
-    //     depth: 0,
-    //     update: false,
-    //     update_all: false,
-    //   }),
-    // });
-
-  //   private async sendUrls(urls: string[]): Promise<boolean> {
-  //   const baseUrl = await this.config.get(GlobalConfigKey.ArchiveBoxBaseUrl, "")
-  //   const tags = await this.config.get(GlobalConfigKey.Tags, "")
-
-  //   if (baseUrl === "") return
-
-  //   const granted = await this.requestPermissionsForHost(baseUrl)
-  //   if (!granted) return false
-
-    const body = new FormData()
-    body.append("url", [url])
-    body.append("tag", tags.join(","))
-    body.append("depth", "0")
-    body.append("parser", "url_list")
-
-  //   this.addQueuedUrlCount(urls.length)
-
-    // const response = await fetch(`${archivebox_server_url}/add/`, {
-    //   method: "post",
-    //   credentials: "include",
-    //   body
-    // })
-  // Instead of direct fetch
-  chrome.runtime.sendMessage({
-    type: 'archivebox_add',
-    url: archivebox_server_url,
-    body: body
-  });
-  //   return true
-  // }
-
+    // NOTE: should we wait for snapshot completion before updating the popup?
     return {
       ok: true,
-      // status: `${response.status} ${response.statusText}`,
-      status: "foo bar",
+      status: "queued"
     };
   } catch (err) {
     return { ok: false, status: `Connection failed ${err}` };

--- a/redesign/popup.js
+++ b/redesign/popup.js
@@ -36,8 +36,6 @@ async function sendToArchiveBox(url, tags) {
 
     const response = chrome.runtime.sendMessage({
       type: 'archivebox_add',
-      url: archivebox_server_url,
-      apiKey: archivebox_api_key,
       body: body
     });
 

--- a/redesign/popup.js
+++ b/redesign/popup.js
@@ -34,9 +34,56 @@ async function sendToArchiveBox(url, tags) {
       }),
     });
 
+    // TODO: Replace
+    // const response = await fetch(`${archivebox_server_url}/api/v1/cli/add`, {
+    //   method: "POST",
+    //   mode: "no-cors",
+    //   credentials: "omit",
+    //   body: JSON.stringify({
+    //     api_key: archivebox_api_key,
+    //     urls: [url],
+    //     tag: tags.join(","),
+    //     depth: 0,
+    //     update: false,
+    //     update_all: false,
+    //   }),
+    // });
+
+  //   private async sendUrls(urls: string[]): Promise<boolean> {
+  //   const baseUrl = await this.config.get(GlobalConfigKey.ArchiveBoxBaseUrl, "")
+  //   const tags = await this.config.get(GlobalConfigKey.Tags, "")
+
+  //   if (baseUrl === "") return
+
+  //   const granted = await this.requestPermissionsForHost(baseUrl)
+  //   if (!granted) return false
+
+    const body = new FormData()
+    body.append("url", [url])
+    body.append("tag", tags.join(","))
+    body.append("depth", "0")
+    body.append("parser", "url_list")
+
+  //   this.addQueuedUrlCount(urls.length)
+
+    // const response = await fetch(`${archivebox_server_url}/add/`, {
+    //   method: "post",
+    //   credentials: "include",
+    //   body
+    // })
+  // Instead of direct fetch
+  chrome.runtime.sendMessage({
+    type: 'archivebox_add',
+    url: archivebox_server_url,
+    body: body
+  });
+  //   return true
+  // }
+
     return {
-      ok: response.ok,
-      status: `${response.status} ${response.statusText}`
+      ok: true,
+      // status: `${response.status} ${response.statusText}`,
+      status: "foo bar",
     };
   } catch (err) {
     return { ok: false, status: `Connection failed ${err}` };
@@ -494,9 +541,11 @@ window.createPopup = async function() {
   input.addEventListener('input', updateDropdown);
 
   // Handle keyboard navigation
-  input.addEventListener('keydown', async (e) => {
-    if (e.key === 'Escape') {
-      dropdownContainer.style.display = 'none';
+  input.addEventListener("keydown", async (e) => {
+    if (e.key === "Escape") {
+      dropdownContainer.style.display = "none";
+      closePopup();
+
       selectedIndex = -1;
       return;
     }
@@ -557,6 +606,12 @@ window.createPopup = async function() {
         break;
     }
   });
+
+  window.closePopup = function () {
+    document.querySelector(".archive-box-iframe")?.remove();
+    window.popup_element = null;
+    console.log("close popup");
+  };
 
   // Handle click selection
   dropdownContainer.addEventListener('click', async (e) => {


### PR DESCRIPTION
These changes (along with a small bug fix in the main ArchiveBox repo) let the extension successfully make a request to a running ArchiveBox server.

This was tested with `v0.8.5rc51`

The request to the REST API is made from the background script, instead of the popup script, to avoid having to deal with CORS issues.

I'm not doing anything with the response from the fetch request for now, but we could probably have an indicator that updates to show that the snapshot was successful.

It seems like the `content_scripts` section of the `manifest.json` was superfluous, and led to errors loading the extension for me, so I removed it.