### PR TITLE
Improve status and error reporting

### DIFF
--- a/redesign/background.js
+++ b/redesign/background.js
@@ -38,7 +38,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       ], ({ archivebox_server_url, archivebox_api_key }) => {
 
         if (!archivebox_server_url || !archivebox_api_key) {
-          sendResponse({ success: false, error: "Server not configured"});
+          sendResponse({ success: false, errorMessage: "Server not configured"});
           return true;
         }
 

--- a/redesign/background.js
+++ b/redesign/background.js
@@ -32,20 +32,33 @@ chrome.action.onClicked.addListener(async (tab) => {
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === 'archivebox_add') {
-    const { archivebox_server_url, archivebox_api_key } = await chrome.storage.local.get([
-        'archivebox_server_url',
-        'archivebox_api_key'
-    ]);
-    const response = fetch(`${archivebox_server_url}/api/v1/cli/add`, {
-      headers: new Headers({
-        "x-archivebox-api-key": `${archivebox_api_key}`
-      }),
-      method: "post",
-      credentials: "include",
-      body: message.body
-    })
-    .then(response => sendResponse(response))
-    .catch(error => sendResponse({error: error.message}));
-    return true; // Required for async response
+      chrome.storage.local.get([
+          'archivebox_server_url',
+          'archivebox_api_key'
+      ], ({ archivebox_server_url, archivebox_api_key }) => {
+
+        if (!archivebox_server_url || !archivebox_api_key) {
+          sendResponse({ success: false, error: "Server not configured"});
+          return true;
+        }
+
+        fetch(`${archivebox_server_url}/api/v1/cli/add`, {
+          headers: {
+            'x-archivebox-api-key': `${archivebox_api_key}`
+          },
+          method: 'post',
+          credentials: 'include',
+          body: message.body
+        })
+        .then(response => response.json())
+        .then(data => {
+          sendResponse({ success: true, data: data });
+        })
+        .catch(error => {
+          sendResponse({ success: false, errorMessage: error.message });
+        });
+      }
+    );
   }
+  return true;
 });

--- a/redesign/popup.js
+++ b/redesign/popup.js
@@ -13,30 +13,38 @@ async function sendToArchiveBox(url, tags) {
     console.log('i Sending to ArchiveBox', { method: 'POST', url, tags });
 
     const body = JSON.stringify({
-      "urls": [url],
-      "tag": tags.join(","),
-      "depth": 0,
-      "update": false,
-      "update_all": false,
-      "index_only": false,
-      "overwrite": false,
-      "init": false,
-      "extractors": "",
-      "parser": "auto"
-    })
-
-    const response = chrome.runtime.sendMessage({
-      type: 'archivebox_add',
-      body: body
+      urls: [url],
+      tag: tags.join(','),
+      depth: 0,
+      update: false,
+      update_all: false,
+      index_only: false,
+      overwrite: false,
+      init: false,
+      extractors: '',
+      parser: 'auto'
     });
 
-    // NOTE: should we wait for snapshot completion before updating the popup?
+    const response = await chrome.runtime.sendMessage({
+        type: 'archivebox_add',
+        body: body
+    });
+
+    if (!response.success) {
+      console.log(`ArchiveBox request failed: ${response.errorMessage}`);
+      return {
+        ok: false,
+        status: response.error
+      };
+    }
+
     return {
       ok: true,
-      status: "queued"
+      status: `${response.data.status} ${response.data.statusText}`
     };
-  } catch (err) {
-    return { ok: false, status: `Connection failed ${err}` };
+  } catch (error) {
+    console.log(`ArchiveBox request failed: ${error.message}`);
+    return { ok: false, status: `Failed to archive: ${error.message}` };
   }
 }
 

--- a/redesign/popup.js
+++ b/redesign/popup.js
@@ -34,7 +34,7 @@ async function sendToArchiveBox(url, tags) {
       console.log(`ArchiveBox request failed: ${response.errorMessage}`);
       return {
         ok: false,
-        status: response.error
+        status: response.errorMessage
       };
     }
 

--- a/redesign/popup.js
+++ b/redesign/popup.js
@@ -9,17 +9,8 @@ async function getAllTags() {
 }
 
 async function sendToArchiveBox(url, tags) {
-  const { archivebox_server_url, archivebox_api_key } = await chrome.storage.local.get([
-    'archivebox_server_url',
-    'archivebox_api_key'
-  ]);
-
-  if (!archivebox_server_url || !archivebox_api_key) {
-    return { ok: false, status: 'Server not configured' };
-  }
-
   try {
-    console.log('i Sending to ArchiveBox', { endpoint: `${archivebox_server_url}/api/v1/cli/add`, method: 'POST', url, tags });
+    console.log('i Sending to ArchiveBox', { method: 'POST', url, tags });
 
     const body = JSON.stringify({
       "urls": [url],


### PR DESCRIPTION
This PR fixes some outstanding issues from #34.

The main focus is on better reporting of errors to the user. In #34, we moved the work of sending API requests to `background.js`, but didn't update the popup with the result of the request. If users hadn't properly configured their extension, or if the ArchiveBox server wasn't running and the fetch request failed, no problems would be reported to them. Now the popup shows the correct error messages.