### PR TITLE
Bugfixes for v2.1.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,6 @@ This is a browser extension that lets you send individual browser tabs or all UR
 5. ✅ *Test it out by right-clicking on any page and selecting `ArchiveBox Exporter > Archive Current Page`*  
     <img width="400" alt="Screenshot of right-clicking to add a page to ArchiveBox using extension" src="https://github.com/ArchiveBox/archivebox-extension/assets/511499/6c0b8125-e1b9-4c64-b79a-c74a8d85c176" align="top"><img width="600" alt="Screenshot of ArchiveBox server with added URL" src="https://github.com/ArchiveBox/archivebox-extension/assets/511499/ab2dc48a-e2cd-4bef-aea3-553a91bc70c9" align="top">
 
-
-## Features
-
-- Different archive modes
-  - Allowlist mode doesn't archive pages by default, and lets you specify domains or regexes to archive
-  - Blocklist mode archives all visited pages by default, but lets you specify domains or regexes to not archive
-- Archive any arbitrary page with the "Archive Current Page" context menu item
-- Archive any link with the "Archive Link" context menu item
-
 ---
 
 ## Development
@@ -85,6 +76,7 @@ Please open an issue to discuss any proposed changes *before* starting work on a
 
 ## Changelog
 
+- 2025-03 New Manifest v3 [Extension v2.1.3](https://github.com/ArchiveBox/archivebox-browser-extension/releases/tag/v2.1.3) Released
 - 2024-11 Development [started](https://github.com/ArchiveBox/archivebox-browser-extension/pull/31) on v2 extension with more advanced UI and tagging options
 - 2024-01 Extension repo moved from `tjhorner/archivebox-exporter` to `Archivebox/archivebox-browser-extension`
 - 2021-09 Extension offically supported by ArchiveBox v0.6.2, no longer needed to run `:dev` branch

--- a/config-tab.js
+++ b/config-tab.js
@@ -1,5 +1,5 @@
 // Config tab initialization and handlers
-import { updateStatusIndicator, syncToArchiveBox } from './utils.js';
+import { updateStatusIndicator, syncToArchiveBox, getArchiveBoxServerUrl } from './utils.js';
 
 export async function initializeConfigTab() {
   const configForm = document.getElementById('configForm');
@@ -8,16 +8,15 @@ export async function initializeConfigTab() {
   const matchUrls = document.getElementById('match_urls');
   
   // Load saved values
-  const savedConfig = await chrome.storage.local.get([
-    'archivebox_server_url',
+  const archivebox_server_url = await getArchiveBoxServerUrl();
+  const { archivebox_api_key, match_urls } = await chrome.storage.local.get([
     'archivebox_api_key',
-    'match_urls',
-    'config_archiveBoxBaseUrl', // old name for archivebox_server_url
+    'match_urls'
   ]);
   
-  serverUrl.value = savedConfig.archivebox_server_url || savedConfig.config_archiveBoxBaseUrl || '';
-  apiKey.value = savedConfig.archivebox_api_key || '';
-  matchUrls.value = savedConfig.match_urls || '';
+  serverUrl.value = archivebox_server_url;
+  apiKey.value = archivebox_api_key || '';
+  matchUrls.value = match_urls || '';
 
   // Server test button handler
   document.getElementById('testServer').addEventListener('click', async () => {

--- a/config-tab.js
+++ b/config-tab.js
@@ -10,10 +10,11 @@ export async function initializeConfigTab() {
   const savedConfig = await chrome.storage.local.get([
     'archivebox_server_url',
     'archivebox_api_key',
-    'match_urls'
+    'match_urls',
+    'config_archiveBoxBaseUrl', // old name for archivebox_server_url
   ]);
   
-  serverUrl.value = savedConfig.archivebox_server_url || '';
+  serverUrl.value = savedConfig.archivebox_server_url || savedConfig.config_archiveBoxBaseUrl || '';
   apiKey.value = savedConfig.archivebox_api_key || '';
   matchUrls.value = savedConfig.match_urls || '';
 
@@ -195,11 +196,13 @@ export async function initializeConfigTab() {
 }
 
 async function syncToArchiveBox(entry) {
-  const { archivebox_server_url, archivebox_api_key } = await chrome.storage.local.get([
+  let { archivebox_server_url, archivebox_api_key, config_archiveBoxBaseUrl } = await chrome.storage.local.get([
     'archivebox_server_url',
-    'archivebox_api_key'
+    'archivebox_api_key',
+    'config_archiveBoxBaseUrl'
   ]);
-
+  archivebox_server_url = archivebox_server_url || config_archiveBoxBaseUrl;
+  
   if (!archivebox_server_url || !archivebox_api_key) {
     return { 
       ok: false, 

--- a/cookies-tab.js
+++ b/cookies-tab.js
@@ -1,6 +1,8 @@
 let availableCookies = [];
 let selectedCookieDomains = new Set();
 
+import { formatCookiesForExport } from './utils.js';
+
 export async function loadAvailableCookies() {
   
 
@@ -90,13 +92,7 @@ async function previewCookies(domain) {
   alert(`${cookies.length} cookies copied to clipboard for "${domain}"!  Save them into cookies.txt on your ArchiveBox server and run: archivebox config --set COOKIES_FILE=/path/to/cookies.txt`);
 }
 
-function formatCookiesForExport(cookies) {
-  return Object.entries(cookies).map(([domain, domainCookies]) => {
-    return `# ${domain}\n${domainCookies.map(cookie => 
-      `${cookie.name}=${cookie.value}; domain=${cookie.domain}; path=${cookie.path}`
-    ).join('\n')}`;
-  }).join('\n\n');
-}
+// Using formatCookiesForExport from utils.js
 
 async function importSelectedCookies() {
   const { activePersona } = await chrome.storage.local.get('activePersona');

--- a/cookies-tab.js
+++ b/cookies-tab.js
@@ -175,8 +175,6 @@ export function initializeCookiesTab() {
   
   document.getElementById('importCookies').addEventListener('click', importSelectedCookies);
   
-  // Load initial data
-  loadAvailableCookies();
 } 
 
 document.getElementById('requestCookiesPermission').addEventListener('click', async () => {

--- a/entries-tab.js
+++ b/entries-tab.js
@@ -1,4 +1,4 @@
-import { filterEntries, addToArchiveBox, downloadCsv, downloadJson, syncToArchiveBox, updateStatusIndicator } from './utils.js';
+import { filterEntries, addToArchiveBox, downloadCsv, downloadJson, syncToArchiveBox, updateStatusIndicator, getArchiveBoxServerUrl } from './utils.js';
 
 export async function renderEntries(filterText = '', tagFilter = '') {
   const { entries = [] } = await chrome.storage.local.get('entries');
@@ -382,8 +382,8 @@ export function initializeEntriesTab() {
 
   // Modify existing renderEntries function
   async function renderEntries() {
-    let { entries = [], archivebox_server_url, config_archiveBoxBaseUrl } = await chrome.storage.local.get(['entries', 'archivebox_server_url', 'config_archiveBoxBaseUrl']);
-    archivebox_server_url = archivebox_server_url || config_archiveBoxBaseUrl;
+    const { entries = [] } = await chrome.storage.local.get(['entries']);
+    const archivebox_server_url = await getArchiveBoxServerUrl();
 
     const filterText = document.getElementById('filterInput').value.toLowerCase();
     const entriesList = document.getElementById('entriesList');

--- a/entries-tab.js
+++ b/entries-tab.js
@@ -391,7 +391,8 @@ export function initializeEntriesTab() {
 
   // Modify existing renderEntries function
   async function renderEntries() {
-    const { entries = [], archivebox_server_url } = await chrome.storage.local.get(['entries', 'archivebox_server_url']);
+    let { entries = [], archivebox_server_url, config_archiveBoxBaseUrl } = await chrome.storage.local.get(['entries', 'archivebox_server_url', 'config_archiveBoxBaseUrl']);
+    archivebox_server_url = archivebox_server_url || config_archiveBoxBaseUrl;
 
     const filterText = document.getElementById('filterInput').value.toLowerCase();
     const entriesList = document.getElementById('entriesList');

--- a/import-tab.js
+++ b/import-tab.js
@@ -22,8 +22,6 @@ export async function initializeImport() {
   document.getElementById('deselectAll').addEventListener('click', () => toggleAllSelection(false));
   document.getElementById('selectAllHeader').addEventListener('change', e => toggleAllSelection(e.target.checked));
   document.getElementById('importSelected').addEventListener('click', importSelected);
-
-  loadHistory();
 }
 
 async function loadHistory() {

--- a/manifest.json
+++ b/manifest.json
@@ -7,10 +7,10 @@
     "storage",
     "scripting",
     "activeTab",
-    "contextMenus"
+    "contextMenus",
+    "unlimitedStorage"
   ],
   "optional_permissions": [
-    "unlimitedStorage",
     "cookies",
     "history",
     "bookmarks"

--- a/options.html
+++ b/options.html
@@ -305,58 +305,9 @@
     <div class="tab-pane fade" id="personas" role="tabpanel">
       <div class="row mt-4">
         <div class="col-md-12">
-<<<<<<< HEAD
-          <div class="mb-4 alert alert-success">
-            <p class="alert-title">
-              <strong>Personas</strong> are a new <i>BETA</i> feature that allow you to more easily manage cookies used to archive sites while logged in.<br/>
-              A persona is similar to a browser profile dedicated to archiving, it's a collection of login credentials your archiving bot can use when it goes to archive sites.<br/>
-              It's recommneded to create at least 2 personas to start:<br/>
-              <ul>
-                <li>a safe anonymous persona that uses only burner temporary accounts so that the archives created are safe to share with the world (<i><a href="https://docs.sweeting.me/s/cookie-dilemma">why use burner credentials for archiving?</a></i>)</li>
-                <li>an unsafe private persona used only for your personal data like social media, email, corporate resources, etc. (the archives generated with this one are safe <a href="https://docs.sweeting.me/s/cookie-dilemma">for your own eyes only</a>!)</li>
-              </ul>
-              <br/>
-            </p>
-            <p class="alert-body">
-              <i>In the future you will be able to sync your personas from this extension to ArchiveBox servers automatically.</i>
-              <br/>
-              For now, a manual export is provided which can be saved into a <a href="https://github.com/ArchiveBox/ArchiveBox/wiki/Configuration#cookies_file"><code>cookies.txt</code> file the ArchiveBox server can use</a>.
-              <br/>
-              <br/>
-              <ol>
-                <li>Create a new persona by clicking the "<strong>Create New Persona</strong>" button below.</li>
-                <li>Set the <strong>Active Persona</strong> to the persona you just created.</li>
-                <li><i>In a new tab:</i> log into all the sites you want to archive using the login credentials you want this persona to use.</li>
-                <li>Then under "Import Browser Cookies" below, select the logins you want to attach to the Persona and click "<strong>Import Cookies to Active Persona</strong>" at the bottom.</li>
-                <li>Click the "<strong>Export Cookies</strong>" button under the persona to get a <code>cookies.txt</code> file, then save that on your server and <a href="https://github.com/ArchiveBox/ArchiveBox/wiki/Configuration#cookies_file">configure ArchiveBox to use it</a>.</li>
-              </ol>
-            </p>
-          </div>
-          
-          <!-- Active Persona Selection -->
-          <div class="card mb-4">
-            <div class="card-body">
-              <div class="d-flex justify-content-between align-items-center mb-3">
-                <div class="d-flex align-items-center">
-                  <h5 class="mb-0 me-3">Active Persona:</h5>
-                  <select class="form-select" id="activePersona" style="width: auto;">
-                    <option value="">Select a persona...</option>
-                  </select>
-                </div>
-                <button class="btn btn-primary" id="newPersona">
-                  Create New Persona
-                </button>
-              </div>
-              <div id="personaStats" class="text-muted small"></div>
-            </div>
-||||||| parent of 405abd3 (latest fixes)
 
           <div class="alert alert-info">
-            Import cookies from this browser into to an archiving profile to re-use those credentials for logged-in archiving.
-=======
-
-          <div class="alert alert-info">
-            <h3>Advanced Users Only: Logged-in Archiving</h3>
+            <h3>Advanced: Logged-in Archiving</h3>
             For <a href="https://github.com/ArchiveBox/ArchiveBox/wiki/Chromium-Install#setting-up-a-chromium-user-profile" style="color: darkblue">Logged-in Archiving</a>, you must set up one or more <code>Archiving Profiles</code> by importing the credentials you need from a browser. 
             An <code>Archiving Profile</code> is ArchiveBox's equivalent to a browser profile, it's a set of cookies or login credentials to the websites you want to capture.<br/>
             <hr/>
@@ -371,7 +322,7 @@ archivebox config --set <a href="https://github.com/ArchiveBox/ArchiveBox/wiki/C
           <div class="alert alert-warning">
             It's recommended to create <a href="https://docs.sweeting.me/s/cookie-dilemma" style="color: darkblue">dedicated separate accounts</a> for archiving and normal browsing to avoid embedding your personal browsing data + cookies headers into the archives.<br/>
             e.g. if you normally log in to Twitter as <code>johndoe@example.com</code>, you should not archive with that account, but instead create a new account for archiving like <code>johndoeswitness@example.com</code>.
->>>>>>> 405abd3 (latest fixes)
+
           </div>
 
           <!-- Persona List -->

--- a/personas-tab.js
+++ b/personas-tab.js
@@ -268,13 +268,7 @@ async function setActivePersona(id) {
   await loadPersonas();
 }
 
-function formatCookiesForExport(cookies) {
-  return Object.entries(cookies).map(([domain, domainCookies]) => {
-    return `# ${domain}\n${domainCookies.map(cookie => 
-      `${cookie.name}=${cookie.value}; domain=${cookie.domain}; path=${cookie.path}`
-    ).join('\n')}`;
-  }).join('\n\n');
-}
+// Using formatCookiesForExport from utils.js
 
 async function exportPersonaCookies(id) {
   const persona = currentPersonas.find(p => p.id === id);
@@ -284,6 +278,8 @@ async function exportPersonaCookies(id) {
   await navigator.clipboard.writeText(text);
   alert(`${Object.keys(persona.cookies).length} domain logins (${Object.values(persona.cookies).reduce((sum, cookies) => sum + cookies.length, 0)} cookies) copied to clipboard for "${persona.name}"! Save them into cookies.txt on your ArchiveBox server and run: archivebox config --set COOKIES_FILE=/path/to/cookies.txt`);
 }
+
+import { formatCookiesForExport } from './utils.js';
 
 export function initializePersonasTab() {
   // Persona management

--- a/popup.js
+++ b/popup.js
@@ -404,7 +404,7 @@ window.createPopup = async function() {
     <div class="ARCHIVEBOX__current-tags"></div><div class="ARCHIVEBOX__tag-suggestions"></div><br/>
     <small class="fade-out">
       <span class="status-indicator"></span>
-      Saved
+      Saving...
     </small>
   `;
 

--- a/popup.js
+++ b/popup.js
@@ -45,8 +45,8 @@ async function sendToArchiveBox(url, tags) {
       });
     })
 
-    ok = addResponse.ok;
-    status = `${addResponse.status} ${addResponse.statusText}`
+    ok = true;
+    status = 'Saved to ArchiveBox Server'
   } catch (error) {
     console.log(`ArchiveBox request failed: ${error}`);
     ok = false;
@@ -409,7 +409,7 @@ window.createPopup = async function() {
     <div class="ARCHIVEBOX__current-tags"></div><div class="ARCHIVEBOX__tag-suggestions"></div><br/>
     <small class="fade-out">
       <span class="status-indicator"></span>
-      Saving...
+      Saved locally...
     </small>
   `;
 

--- a/popup.js
+++ b/popup.js
@@ -30,7 +30,7 @@ async function sendToArchiveBox(url, tags) {
 
     const addCommandArgs = JSON.stringify({
       urls: [url],
-      tag: tags.join(','),
+      tags: tags.join(','),
     });
 
     const addResponse = await new Promise((resolve, reject) => {

--- a/popup.js
+++ b/popup.js
@@ -234,7 +234,7 @@ window.createPopup = async function() {
     }
 
     .archive-box-popup small.fade-out {
-      animation: fadeOut 2.5s ease-in-out forwards;
+      animation: fadeOut 10s ease-in-out forwards;
     }
     
     .archive-box-popup img {

--- a/utils.js
+++ b/utils.js
@@ -64,9 +64,13 @@ export async function addToArchiveBox(addCommandArgs, onComplete, onError) {
     // fall back to pre-v0.8.0 endpoint for backwards compatibility
     console.log('i addToArchiveBox using legacy /add POST method');
 
+    const parsedAddCommandArgs = JSON.parse(addCommandArgs);
+    const urls = parsedAddCommandArgs && parsedAddCommandArgs.urls
+      ? parsedAddCommandArgs.urls.join("\n") : "";
+    const tags = parsedAddCommandArgs && parsedAddCommandArgs.tags
+      ? parsedAddCommandArgs.tags : "";
+
     const body = new FormData();
-    const urls = addCommandArgs && addCommandArgs.urls ? addCommandArgs.urls.join("\n") : "";
-    const tags = addCommandArgs && addCommandArgs.tags ? addCommandArgs.tags : "";
     body.append("url", urls);
     body.append("tag", tags);
     body.append("only_new", "1");

--- a/utils.js
+++ b/utils.js
@@ -73,7 +73,8 @@ export async function addToArchiveBox(addCommandArgs, onComplete, onError) {
     const body = new FormData();
     body.append("url", urls);
     body.append("tag", tags);
-    body.append("only_new", "1");
+    body.append("parser", "auto")
+    body.append("depth", 0)
 
     try {
       const response = await fetch(`${archivebox_server_url}/add/`, {

--- a/utils.js
+++ b/utils.js
@@ -30,7 +30,7 @@ export async function addToArchiveBox(addCommandArgs, onComplete, onError) {
       });
     });
 
-    console.log('i addToArchiveBox', archivebox_server_url, addCommandArgs);
+    console.log('i addToArchiveBox server url', archivebox_server_url);
     if (!archivebox_server_url) {
       throw new Error('Server not configured.');
     }

--- a/utils.js
+++ b/utils.js
@@ -21,17 +21,17 @@ export async function addToArchiveBox(addCommandArgs, onComplete, onError) {
   console.log('i addToArchiveBox', addCommandArgs);
   try {
     const { archivebox_server_url, archivebox_api_key } = await new Promise((resolve, reject) => {
-      chrome.storage.local.get(['archivebox_server_url', 'archivebox_api_key'], (vals) => {
+      chrome.storage.local.get(['archivebox_server_url', 'archivebox_api_key', 'config_archiveBoxBaseUrl'], (vals) => {
         if (chrome.runtime.lastError) {
           reject(chrome.runtime.lastError);
         } else {
-          resolve(vals);
+          resolve({archivebox_server_url: vals.archivebox_server_url || vals.config_archiveBoxBaseUrl, archivebox_api_key: vals.archivebox_api_key});
         }
       });
     });
 
     console.log('i addToArchiveBox server url', archivebox_server_url);
-    if (!archivebox_server_url) {
+    if (archivebox_server_url) {
       throw new Error('Server not configured.');
     }
 

--- a/utils.js
+++ b/utils.js
@@ -2,10 +2,8 @@
 
 // Helper to get server URL with fallback to legacy config name
 export async function getArchiveBoxServerUrl() {
-  const { archivebox_server_url, config_archiveBoxBaseUrl } = await chrome.storage.local.get([
-    'archivebox_server_url',
-    'config_archiveBoxBaseUrl'
-  ]);
+  const { archivebox_server_url } = await chrome.storage.local.get(['archivebox_server_url']);    // new ArchiveBox Extension v2.1.3 location
+  const {config_archiveBoxBaseUrl} = await chrome.storage.sync.get(['config_archiveBoxBaseUrl']); // old ArchiveBox Exporter v1.3.1 location
   return archivebox_server_url || config_archiveBoxBaseUrl || '';
 }
 


### PR DESCRIPTION
Fixes the major bugs and some UI issues mentioned in #40.

Priorities:

- [x] fix `if (archivebox_api_key)` bug not submitting if API Key field is empty, which breaks v0.7.3 if key field is left empty
- [x] change the popup to say `Saved locally...` first, and then `Saved to ArchiveBox Server` later after the POST request completes
- [x] port over the server base URL and regex match patterns from the previous extension config `chrome.storage`

---
- [x] `manifest.json` error (unlimitedStorage can't be listed as optional permission)
- [x] when opening config page, `loadHistory` function requires user gesture
- [ ] ~look at how the old extension automatically added specific tags~ (save this for another PR)