### PR TITLE
Make auto archiving work

### DIFF
--- a/background.js
+++ b/background.js
@@ -109,7 +109,6 @@ async function configureAutoArchiving() {
 
   if (!hasPermission) {
     console.log('Tabs permission not granted, auto-archiving disabled');
-    chrome.storage.local.set({ enable_auto_archive: false });
     return;
   }
 

--- a/background.js
+++ b/background.js
@@ -2,6 +2,17 @@
 
 import { addToArchiveBox } from "./utils.js";
 
+class Entry {
+  constructor(url, tags, title, favIconUrl) {
+    this.id = crypto.randomUUID(),
+    this.url = url,
+    this.timestamp = new Date().toISOString(),
+    this.tags = tags,
+    this.title = title,
+    this.favicon = favIconUrl
+  }
+}
+
 chrome.runtime.onMessage.addListener(async (message) => {
     const options_url = chrome.runtime.getURL('options.html') + `?search=${message.id}`;
     console.log('i ArchiveBox Collector showing options.html', options_url);
@@ -72,14 +83,12 @@ async function setupAutoArchiving() {
           if (await shouldAutoArchive(tab.url)) {
             console.log('Auto-archiving URL:', tab.url);
 
-            const entry = {
-              id: crypto.randomUUID(),
-              url: tab.url,
-              timestamp: new Date().toISOString(),
-              tags: ['auto-archived'],
-              title: tab.title,
-              favicon: tab.favIconUrl
-            };
+            const entry = new Entry(
+              tab.url,
+              ['auto-archived'],
+              tab.title,
+              tab.favIconUrl,
+            );
 
             const { entries = [] } = await chrome.storage.local.get('entries');
             entries.push(entry);
@@ -118,14 +127,12 @@ chrome.storage.onChanged.addListener((changes, area) => {
 });
 
 chrome.action.onClicked.addListener(async (tab) => {
-  const entry = {
-    id: crypto.randomUUID(),
-    url: tab.url,
-    timestamp: new Date().toISOString(),
-    tags: [],
-    title: tab.title,
-    favicon: tab.favIconUrl
-  };
+  const entry = new Entry(
+    tab.url,
+    [],
+    tab.title,
+    tab.favIconUrl,
+  );
 
   // Save the entry first
   const { entries = [] } = await chrome.storage.local.get('entries');
@@ -159,14 +166,12 @@ chrome.contextMenus.onClicked.addListener(onClickContextMenuSave);
 
 // A generic onclick callback function.
 async function onClickContextMenuSave(item, tab) {
-  const entry = {
-    id: crypto.randomUUID(),
-    url: tab.url,
-    timestamp: new Date().toISOString(),
-    tags: [],
-    title: tab.title,
-    favicon: tab.favIconUrl
-  };
+  const entry = new Entry(
+    tab.url,
+    [],
+    tab.title,
+    tab.favIconUrl,
+  );
 
   // Save the entry first
   const { entries = [] } = await chrome.storage.local.get('entries');

--- a/background.js
+++ b/background.js
@@ -26,7 +26,7 @@ async function shouldAutoArchive(url) {
   try {
     console.debug(`[Auto-Archive Debug] Checking URL: ${url}`);
 
-    const { enable_auto_archive, match_urls, exclude_urls } = await chrome.storage.local.get([
+    const { enable_auto_archive=false, match_urls=[], exclude_urls=[] } = await chrome.storage.local.get([
       'enable_auto_archive',
       'match_urls',
       'exclude_urls',
@@ -47,7 +47,7 @@ async function shouldAutoArchive(url) {
       return false;
     }
 
-    if (exclude_urls && exclude_urls.trim() !== '') {
+    if (exclude_urls.trim()) {
       try {
         const excludePattern = new RegExp(exclude_urls);
         const excluded = excludePattern.test(url);
@@ -78,8 +78,8 @@ async function setupAutoArchiving() {
   console.debug(`[Auto-Archive Debug] enable_auto_archive setting: ${enable_auto_archive}`);
 
   if (tabUpdateListener) {
+    console.debug('[Auto-Archive Debug] Removing existing tab update listener');
     try {
-      console.debug('[Auto-Archive Debug] Removing existing tab update listener');
       chrome.tabs.onUpdated.removeListener(tabUpdateListener);
       tabUpdateListener = null;
     } catch (error) {

--- a/background.js
+++ b/background.js
@@ -74,7 +74,7 @@ let tabUpdateListener = null;
 
 async function setupAutoArchiving() {
   console.debug('[Auto-Archive Debug] Setting up auto-archiving...');
-  const { enable_auto_archive } = await chrome.storage.local.get(['enable_auto_archive']);
+  const { enable_auto_archive=false } = await chrome.storage.local.get(['enable_auto_archive']);
   console.debug(`[Auto-Archive Debug] enable_auto_archive setting: ${enable_auto_archive}`);
 
   if (tabUpdateListener) {

--- a/background.js
+++ b/background.js
@@ -107,7 +107,7 @@ async function setupAutoArchiving() {
 
         // Check if URL is already archived locally
         const { snapshots = [] } = await chrome.storage.local.get('snapshots');
-        const isAlreadyArchived = snapshots.some(s => s.url.trim() === tab.url.trim());
+        const isAlreadyArchived = snapshots.some(s => s.url === tab.url);
 
         if (isAlreadyArchived) {
           console.debug(`[Auto-Archive Debug] URL already archived, skipping: ${tab.url}`);

--- a/background.js
+++ b/background.js
@@ -1,6 +1,6 @@
 // background.js
 
-import { addToArchiveBox } from "./utils.js";
+import { addToArchiveBox, syncToArchiveBox } from "./utils.js";
 
 chrome.runtime.onMessage.addListener(async (message) => {
     const options_url = chrome.runtime.getURL('options.html') + `?search=${message.id}`;
@@ -9,6 +9,109 @@ chrome.runtime.onMessage.addListener(async (message) => {
       await chrome.tabs.create({ url: options_url });
     }
   });
+
+// Function to check if URL should be auto-archived based on regex patterns
+async function shouldAutoArchive(url) {
+  try {
+    const { enable_auto_archive, match_urls, exclude_urls } = await chrome.storage.local.get([
+      'enable_auto_archive',
+      'match_urls',
+      'exclude_urls',
+    ]);
+
+    if (!enable_auto_archive || !match_urls || match_urls.trim() === '') {
+      return false;
+    }
+
+    const matchPattern = new RegExp(match_urls);
+
+    if (!matchPattern.test(url)) {
+      return false;
+    }
+
+    if (exclude_urls && exclude_urls.trim() !== '') {
+      try {
+        const excludePattern = new RegExp(exclude_urls);
+        if (excludePattern.test(url)) {
+          return false;
+        }
+      } catch (error) {
+        console.error('Invalid exclude pattern:', error);
+      }
+    }
+
+    return true;
+  } catch (error) {
+    console.error('Error checking auto-archive patterns:', error);
+    return false;
+  }
+}
+
+// Global reference to the listener so we can remove it properly
+let tabUpdateListener = null;
+
+async function setupAutoArchiving() {
+  const { enable_auto_archive } = await chrome.storage.local.get(['enable_auto_archive']);
+
+  if (tabUpdateListener) {
+    try {
+      chrome.tabs.onUpdated.removeListener(tabUpdateListener);
+      tabUpdateListener = null;
+    } catch (error) {
+      console.error('Error removing listener:', error);
+    }
+  }
+
+  if (enable_auto_archive) {
+    const hasPermission = await chrome.permissions.contains({ permissions: ['tabs'] });
+
+    if (hasPermission) {
+      tabUpdateListener = async (tabId, changeInfo, tab) => {
+        // Only process when the page has completed loading
+        if (changeInfo.status === 'complete' && tab.url) {
+          if (await shouldAutoArchive(tab.url)) {
+            console.log('Auto-archiving URL:', tab.url);
+
+            const entry = {
+              id: crypto.randomUUID(),
+              url: tab.url,
+              timestamp: new Date().toISOString(),
+              tags: ['auto-archived'],
+              title: tab.title,
+              favicon: tab.favIconUrl
+            };
+
+            const { entries = [] } = await chrome.storage.local.get('entries');
+            entries.push(entry);
+            await chrome.storage.local.set({ entries });
+
+            const result = await syncToArchiveBox(entry);
+            console.log('Auto-archive result:', result);
+          }
+        }
+      };
+
+      chrome.tabs.onUpdated.addListener(tabUpdateListener);
+      console.log('Auto-archiving enabled with tabs permission');
+    } else {
+      console.log('Tabs permission not granted, auto-archiving disabled');
+      // Reset the toggle if permission was not granted
+      chrome.storage.local.set({ enable_auto_archive: false });
+    }
+  } else {
+    console.log('Auto-archiving disabled');
+  }
+}
+
+// Initialize auto-archiving setup on extension load
+setupAutoArchiving();
+
+// Listen for changes to the auto-archive setting
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === 'local' && changes.enable_auto_archive) {
+    setupAutoArchiving();
+  }
+});
 
 chrome.action.onClicked.addListener(async (tab) => {
   const entry = {
@@ -19,12 +122,12 @@ chrome.action.onClicked.addListener(async (tab) => {
     title: tab.title,
     favicon: tab.favIconUrl
   };
-  
+
   // Save the entry first
   const { entries = [] } = await chrome.storage.local.get('entries');
   entries.push(entry);
   await chrome.storage.local.set({ entries });
-  
+
   // Inject scripts - CSS now handled in popup.js
   await chrome.scripting.executeScript({
     target: { tabId: tab.id },
@@ -37,7 +140,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     addToArchiveBox(message.body, sendResponse, sendResponse);
   }
   return true;
-});
+
 
 
 chrome.contextMenus.onClicked.addListener(onClickContextMenuSave);
@@ -52,12 +155,12 @@ async function onClickContextMenuSave(item, tab) {
     title: tab.title,
     favicon: tab.favIconUrl
   };
-  
+
   // Save the entry first
   const { entries = [] } = await chrome.storage.local.get('entries');
   entries.push(entry);
   await chrome.storage.local.set({ entries });
-  
+
   // Inject scripts - CSS now handled in popup.js
   await chrome.scripting.executeScript({
     target: { tabId: tab.id },

--- a/background.js
+++ b/background.js
@@ -168,7 +168,7 @@ async function setupAutoArchiving() {
 
           try {
             console.debug(`[Auto-Archive Debug] Calling addToArchiveBox with URL: ${snapshot.url}, tags: ${snapshot.tags.join(',')}`);
-            await addToArchiveBox([snapshot.url], snapshot.tags.join(','));
+            await addToArchiveBox([snapshot.url], snapshot.tags);
             console.log(`Automatically archived ${snapshot.url}`);
           } catch (error) {
             console.error(`Failed to automatically archive ${snapshot.url}: ${error.message}`);
@@ -218,7 +218,7 @@ chrome.action.onClicked.addListener(async (tab) => {
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === 'archivebox_add') {
     try {
-      const { urls = [], tags='' } = JSON.parse(message.body);
+      const { urls = [], tags=[] } = JSON.parse(message.body);
 
       addToArchiveBox(urls, tags)
         .then(() => {

--- a/background.js
+++ b/background.js
@@ -238,28 +238,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 });
 
 
-chrome.contextMenus.onClicked.addListener(onClickContextMenuSave);
-
-// A generic onclick callback function.
-async function onClickContextMenuSave(item, tab) {
-  const snapshot = new Snapshot(
-    tab.url,
-    [],
-    tab.title,
-    tab.favIconUrl,
-  );
-
-  // Save the snapshot first
-  const { snapshots = [] } = await chrome.storage.local.get('snapshots');
-  snapshots.push(snapshot);
-  await chrome.storage.local.set({ snapshots });
-
-  // Inject scripts - CSS now handled in popup.js
-  await chrome.scripting.executeScript({
+chrome.contextMenus.onClicked.addListener((item, tab) =>
+  chrome.scripting.executeScript({
     target: { tabId: tab.id },
     files: ['popup.js']
-  });
-}
+  })
+);
 
 chrome.runtime.onInstalled.addListener(function () {
   chrome.contextMenus.removeAll();

--- a/background.js
+++ b/background.js
@@ -2,14 +2,14 @@
 
 import { addToArchiveBox } from "./utils.js";
 
-class Entry {
+class Snapshot {
   constructor(url, tags, title, favIconUrl) {
-    this.id = crypto.randomUUID(),
-    this.url = url,
-    this.timestamp = new Date().toISOString(),
-    this.tags = tags,
-    this.title = title,
-    this.favicon = favIconUrl
+    this.id = crypto.randomUUID();
+    this.url = url;
+    this.timestamp = new Date().toISOString();
+    this.tags = tags;
+    this.title = title;
+    this.favicon = favIconUrl;
   }
 }
 
@@ -106,25 +106,25 @@ async function setupAutoArchiving() {
           if (shouldArchive) {
             console.log('Auto-archiving URL:', tab.url);
 
-            const entry = new Entry(
+            const snapshot = new Snapshot(
               tab.url,
               ['auto-archived'],
               tab.title,
               tab.favIconUrl,
             );
 
-            console.debug('[Auto-Archive Debug] Created new entry, saving to storage');
-            const { entries = [] } = await chrome.storage.local.get('entries');
-            entries.push(entry);
-            await chrome.storage.local.set({ entries });
-            console.debug('[Auto-Archive Debug] Entry saved to local storage');
+            console.debug('[Auto-Archive Debug] Created new snapshot, saving to storage');
+            const { snapshots = [] } = await chrome.storage.local.get('snapshots');
+            snapshots.push(snapshot);
+            await chrome.storage.local.set({ snapshots });
+            console.debug('[Auto-Archive Debug] Snapshot saved to local storage');
 
             try {
-              console.debug(`[Auto-Archive Debug] Calling addToArchiveBox with URL: ${entry.url}, tags: ${entry.tags.join(',')}`);
-              await addToArchiveBox([entry.url], entry.tags.join(','));
-              console.log(`Automatically archived ${entry.url}`);
+              console.debug(`[Auto-Archive Debug] Calling addToArchiveBox with URL: ${snapshot.url}, tags: ${snapshot.tags.join(',')}`);
+              await addToArchiveBox([snapshot.url], snapshot.tags.join(','));
+              console.log(`Automatically archived ${snapshot.url}`);
             } catch (error) {
-              console.error(`Failed to automatically archive ${entry.url}: ${error.message}`);
+              console.error(`Failed to automatically archive ${snapshot.url}: ${error.message}`);
             }
           }
         }
@@ -155,17 +155,17 @@ chrome.storage.onChanged.addListener((changes, area) => {
 });
 
 chrome.action.onClicked.addListener(async (tab) => {
-  const entry = new Entry(
+  const snapshot = new Snapshot(
     tab.url,
     [],
     tab.title,
     tab.favIconUrl,
   );
 
-  // Save the entry first
-  const { entries = [] } = await chrome.storage.local.get('entries');
-  entries.push(entry);
-  await chrome.storage.local.set({ entries });
+  // Save the snapshot first
+  const { snapshots = [] } = await chrome.storage.local.get('snapshots');
+  snapshots.push(snapshot);
+  await chrome.storage.local.set({ snapshots });
 
   // Inject scripts - CSS now handled in popup.js
   await chrome.scripting.executeScript({
@@ -194,17 +194,17 @@ chrome.contextMenus.onClicked.addListener(onClickContextMenuSave);
 
 // A generic onclick callback function.
 async function onClickContextMenuSave(item, tab) {
-  const entry = new Entry(
+  const snapshot = new Snapshot(
     tab.url,
     [],
     tab.title,
     tab.favIconUrl,
   );
 
-  // Save the entry first
-  const { entries = [] } = await chrome.storage.local.get('entries');
-  entries.push(entry);
-  await chrome.storage.local.set({ entries });
+  // Save the snapshot first
+  const { snapshots = [] } = await chrome.storage.local.get('snapshots');
+  snapshots.push(snapshot);
+  await chrome.storage.local.set({ snapshots });
 
   // Inject scripts - CSS now handled in popup.js
   await chrome.scripting.executeScript({

--- a/background.js
+++ b/background.js
@@ -212,7 +212,9 @@ async function onClickContextMenuSave(item, tab) {
     files: ['popup.js']
   });
 }
+
 chrome.runtime.onInstalled.addListener(function () {
+  chrome.contextMenus.removeAll();
   chrome.contextMenus.create({
     id: 'save_to_archivebox_ctxmenu',
     title: 'Save to ArchiveBox',

--- a/config-tab.js
+++ b/config-tab.js
@@ -10,7 +10,7 @@ export async function initializeConfigTab() {
 
   // Load saved values
   const archivebox_server_url = await getArchiveBoxServerUrl();
-  const { archivebox_api_key, match_urls, exclude_urls, enable_auto_archive } = await chrome.storage.local.get([
+  const { archivebox_api_key='', match_urls='', exclude_urls='', enable_auto_archive=false } = await chrome.storage.local.get([
     'archivebox_api_key',
     'match_urls',
     'exclude_urls',

--- a/config-tab.js
+++ b/config-tab.js
@@ -227,7 +227,7 @@ export async function initializeConfigTab() {
 
         document.getElementById('inprogress-test').remove();
 
-        await addToArchiveBox([testSnapshot.url], testSnapshot.tags.join(','));
+        await addToArchiveBox([testSnapshot.url], testSnapshot.tags);
 
         testStatus.innerHTML += `
           &nbsp; <span class="status-indicator status-success"></span>

--- a/config-tab.js
+++ b/config-tab.js
@@ -19,7 +19,7 @@ export async function initializeConfigTab() {
   console.log('Got config values from storage:', archivebox_server_url, archivebox_api_key, match_urls, exclude_urls, enable_auto_archive);
 
   // migrate old config_archiveboxBaseUrl to archivebox_server_url
-  const {config_archiveBoxBaseUrl} = await chrome.storage.sync.get('config_archiveboxBaseUrl', );
+  const {config_archiveBoxBaseUrl} = await chrome.storage.sync.get('config_archiveboxBaseUrl');
   if (config_archiveBoxBaseUrl) {
     await chrome.storage.local.set({ archivebox_server_url: config_archiveBoxBaseUrl });
   }
@@ -30,8 +30,8 @@ export async function initializeConfigTab() {
   excludeUrls.value = typeof exclude_urls === 'string' ? exclude_urls : '';
 
   // Set the auto-archive toggle state
-  const enableAutoArchive = document.getElementById('enable_auto_archive');
-  enableAutoArchive.checked = !!enable_auto_archive;
+  const autoArchiveCheckbox = document.getElementById('enable_auto_archive');
+  autoArchiveCheckbox.checked = !!enable_auto_archive;
 
   // Server test button handler
   document.getElementById('testServer').addEventListener('click', async () => {
@@ -125,17 +125,17 @@ export async function initializeConfigTab() {
   });
 
   // Special handler for the auto-archive toggle
-  enableAutoArchive.addEventListener('change', async () => {
-    if (enableAutoArchive.checked) {
+  autoArchiveCheckbox.addEventListener('change', async () => {
+    if (autoArchiveCheckbox.checked) {
       const granted = await chrome.permissions.request({ permissions: ['tabs'] });
       if (!granted) {
-        enableAutoArchive.checked = false;
+        autoArchiveCheckbox.checked = false;
         alert('The "tabs" permission is required for auto-archiving. Auto-archiving has been disabled.');
       }
     }
 
     await chrome.storage.local.set({
-      enable_auto_archive: enableAutoArchive.checked
+      enable_auto_archive: autoArchiveCheckbox.checked
     });
   });
 

--- a/config-tab.js
+++ b/config-tab.js
@@ -19,7 +19,7 @@ export async function initializeConfigTab() {
   ]);
   console.log('Got config values from storage:', archivebox_server_url, archivebox_api_key, match_urls, exclude_urls, enable_auto_archive);
 
-  // migrate old config_archiveboxBaseUrl to archivebox_server_url
+  // Migrate old config_archiveboxBaseUrl to archivebox_server_url
   const {config_archiveBoxBaseUrl} = await chrome.storage.sync.get('config_archiveboxBaseUrl');
   if (config_archiveBoxBaseUrl) {
     await chrome.storage.local.set({ archivebox_server_url: config_archiveBoxBaseUrl });

--- a/config-tab.js
+++ b/config-tab.js
@@ -159,7 +159,16 @@ export async function initializeConfigTab() {
   testButton.addEventListener('click', async () => {
     const url = testUrlInput.value.trim();
 
+    if (!url) {
+      testStatus.innerHTML = `
+        <span class="status-indicator status-error"></span>
+        ⌨️ Please enter a URL to test
+      `;
+      return;
+    }
+
     // test if the URL matches the regex match patterns
+    let shouldArchive = false;
     let matchPattern;
     try {
       matchPattern = new RegExp(matchUrls.value || /^$/);
@@ -176,6 +185,7 @@ export async function initializeConfigTab() {
         <span class="status-indicator status-success"></span>
         ➕ URL would be auto-archived when visited<br/>
       `;
+      shouldArchive = true;
     } else {
       testStatus.innerHTML = `
         <span class="status-indicator status-warning"></span>
@@ -192,6 +202,7 @@ export async function initializeConfigTab() {
         <span class="status-indicator status-warning"></span>
           🚫 URL is excluded from auto-archiving (but it can still be saved manually)<br/>
         `;
+        shouldArchive = false;
       }
     } catch (error) {
       testStatus.innerHTML = `
@@ -200,48 +211,42 @@ export async function initializeConfigTab() {
       `;
     }
 
-    if (!url) {
-      testStatus.innerHTML = `
-        <span class="status-indicator status-error"></span>
-        ⌨️ Please enter a URL to test
-      `;
-      return;
-    }
-
-    // Show loading state
-    testButton.disabled = true;
-    testStatus.innerHTML += `
-      <span id="inprogress-test">
-        &nbsp; &nbsp; <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
-        Submitting...
-      </span>
-    `;
-
-    try {
-      const testEntry = {
-        url,
-        title: 'Test Entry',
-        timestamp: new Date().toISOString(),
-        tags: ['test']
-      };
-
-      document.getElementById('inprogress-test').remove();
-
-      await addToArchiveBox([testEntry.url], testEntry.tags.join(','));
-
+    if (shouldArchive) {
+      // Show loading state
+      testButton.disabled = true;
       testStatus.innerHTML += `
-        &nbsp; <span class="status-indicator status-success"></span>
-        🚀 URL was submitted and <a href="${serverUrl.value}/" target="_blank">✓ queued for archiving</a> on the ArchiveBox server: <a href="${serverUrl.value}/archive/${testEntry.url}" target="_blank">📦 <code>${serverUrl.value}/archive/${testEntry.url}</code></a>.
+        <span id="inprogress-test">
+          &nbsp; &nbsp; <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+          Submitting...
+        </span>
       `;
-      // Clear the input on success
-      testUrlInput.value = '';
-    } catch (error) {
-      testStatus.innerHTML += `
-        <span class="status-indicator status-error"></span>
-        Error: ${error.message}
-      `;
-    } finally {
-      testButton.disabled = false;
+
+      try {
+        const testEntry = {
+          url,
+          title: 'Test Entry',
+          timestamp: new Date().toISOString(),
+          tags: ['test']
+        };
+
+        document.getElementById('inprogress-test').remove();
+
+        await addToArchiveBox([testEntry.url], testEntry.tags.join(','));
+
+        testStatus.innerHTML += `
+          &nbsp; <span class="status-indicator status-success"></span>
+          🚀 URL was submitted and <a href="${serverUrl.value}/" target="_blank">✓ queued for archiving</a> on the ArchiveBox server: <a href="${serverUrl.value}/archive/${testEntry.url}" target="_blank">📦 <code>${serverUrl.value}/archive/${testEntry.url}</code></a>.
+        `;
+        // Clear the input on success
+        testUrlInput.value = '';
+      } catch (error) {
+        testStatus.innerHTML += `
+          <span class="status-indicator status-error"></span>
+          Error: ${error.message}
+        `;
+      } finally {
+        testButton.disabled = false;
+      }
     }
   });
 

--- a/config-tab.js
+++ b/config-tab.js
@@ -1,5 +1,6 @@
 // Config tab initialization and handlers
-import { updateStatusIndicator, getArchiveBoxServerUrl, addToArchiveBox } from './utils.js';
+
+import { Snapshot, updateStatusIndicator, getArchiveBoxServerUrl, addToArchiveBox } from './utils.js';
 
 export async function initializeConfigTab() {
   const configForm = document.getElementById('configForm');
@@ -222,12 +223,7 @@ export async function initializeConfigTab() {
       `;
 
       try {
-        const testSnapshot = {
-          url,
-          title: 'Test Snapshot',
-          timestamp: new Date().toISOString(),
-          tags: ['test']
-        };
+        const testSnapshot = new Snapshot(url, ['test'], 'Test Snapshot');
 
         document.getElementById('inprogress-test').remove();
 

--- a/config-tab.js
+++ b/config-tab.js
@@ -222,20 +222,20 @@ export async function initializeConfigTab() {
       `;
 
       try {
-        const testEntry = {
+        const testSnapshot = {
           url,
-          title: 'Test Entry',
+          title: 'Test Snapshot',
           timestamp: new Date().toISOString(),
           tags: ['test']
         };
 
         document.getElementById('inprogress-test').remove();
 
-        await addToArchiveBox([testEntry.url], testEntry.tags.join(','));
+        await addToArchiveBox([testSnapshot.url], testSnapshot.tags.join(','));
 
         testStatus.innerHTML += `
           &nbsp; <span class="status-indicator status-success"></span>
-          🚀 URL was submitted and <a href="${serverUrl.value}/" target="_blank">✓ queued for archiving</a> on the ArchiveBox server: <a href="${serverUrl.value}/archive/${testEntry.url}" target="_blank">📦 <code>${serverUrl.value}/archive/${testEntry.url}</code></a>.
+          🚀 URL was submitted and <a href="${serverUrl.value}/" target="_blank">✓ queued for archiving</a> on the ArchiveBox server: <a href="${serverUrl.value}/archive/${testSnapshot.url}" target="_blank">📦 <code>${serverUrl.value}/archive/${testSnapshot.url}</code></a>.
         `;
         // Clear the input on success
         testUrlInput.value = '';

--- a/import-tab.js
+++ b/import-tab.js
@@ -2,7 +2,7 @@ let importItems = [];
 let existingUrls = new Set();
 
 export async function initializeImport() {
-  const { snapshots = [] } = await chrome.storage.local.get('snapshots');
+  const { entries: snapshots = [] } = await chrome.storage.local.get('entries');
   existingUrls = new Set(snapshots.map(e => e.url));
   
   // Set default dates for history
@@ -176,7 +176,7 @@ async function importSelected() {
     .map(tag => tag.trim())
     .filter(tag => tag);
   
-  const { snapshots = [] } = await chrome.storage.local.get('snapshots');
+  const { entries: snapshots = [] } = await chrome.storage.local.get('entries');
   
   const newSnapshots = selectedItems.map(item => ({
     id: crypto.randomUUID(),
@@ -188,7 +188,7 @@ async function importSelected() {
   }));
   
   snapshots.push(...newSnapshots);
-  await chrome.storage.local.set({ snapshots });
+  await chrome.storage.local.set({ entries: snapshots });
   
   // Update existingUrls
   newSnapshots.forEach(snapshot => existingUrls.add(snapshot.url));

--- a/import-tab.js
+++ b/import-tab.js
@@ -2,8 +2,8 @@ let importItems = [];
 let existingUrls = new Set();
 
 export async function initializeImport() {
-  const { entries = [] } = await chrome.storage.local.get('entries');
-  existingUrls = new Set(entries.map(e => e.url));
+  const { snapshots = [] } = await chrome.storage.local.get('snapshots');
+  existingUrls = new Set(snapshots.map(e => e.url));
   
   // Set default dates for history
   const endDate = new Date();
@@ -176,9 +176,9 @@ async function importSelected() {
     .map(tag => tag.trim())
     .filter(tag => tag);
   
-  const { entries = [] } = await chrome.storage.local.get('entries');
+  const { snapshots = [] } = await chrome.storage.local.get('snapshots');
   
-  const newEntries = selectedItems.map(item => ({
+  const newSnapshots = selectedItems.map(item => ({
     id: crypto.randomUUID(),
     url: item.url,
     title: item.title,
@@ -187,11 +187,11 @@ async function importSelected() {
     notes: ''
   }));
   
-  entries.push(...newEntries);
-  await chrome.storage.local.set({ entries });
+  snapshots.push(...newSnapshots);
+  await chrome.storage.local.set({ snapshots });
   
   // Update existingUrls
-  newEntries.forEach(entry => existingUrls.add(entry.url));
+  newSnapshots.forEach(snapshot => existingUrls.add(snapshot.url));
   
   // Clear selections and re-render
   importItems.forEach(item => item.selected = false);
@@ -201,7 +201,7 @@ async function importSelected() {
   document.getElementById('importTags').value = '';
   
   // Show success message
-  alert(`Successfully imported ${newEntries.length} items`);
+  alert(`Successfully imported ${newSnapshots.length} items`);
 
   // redirect back to the URLs tab
   window.location.reload();

--- a/import-tab.js
+++ b/import-tab.js
@@ -184,7 +184,6 @@ async function importSelected() {
     title: item.title,
     timestamp: new Date().toISOString(),
     tags: [...tags],
-    notes: ''
   }));
   
   snapshots.push(...newSnapshots);

--- a/import-tab.js
+++ b/import-tab.js
@@ -204,4 +204,4 @@ async function importSelected() {
 
   // redirect back to the URLs tab
   window.location.reload();
-} 
+}

--- a/manifest.json
+++ b/manifest.json
@@ -13,10 +13,11 @@
   "optional_permissions": [
     "cookies",
     "history",
-    "bookmarks"
+    "bookmarks",
+    "tabs"
   ],
   "optional_host_permissions": [
-    "*://*\/*"
+    "<all_urls>"
   ],
   "icons": {
     "16": "16.png",

--- a/options.html
+++ b/options.html
@@ -254,7 +254,16 @@
             <br/>
             <hr/>
             <br/>
-            <h5>Advanced Users Only: Auto-archive URLs</h5><br/>
+            <h5>Advanced Users Only: Auto-archive URLs</h5>
+            <div class="form-check mb-3">
+              <input class="form-check-input" type="checkbox" id="enable_auto_archive">
+              <label class="form-check-label" for="enable_auto_archive">
+                Enable automatic archiving
+              </label>
+              <div class="form-text">
+                When enabled, the extension will automatically archive URLs that match the patterns below.
+              </div>
+            </div>
             <div class="mb-3">
               <label for="match_urls" class="form-label">➕ Auto-archive all visited URLs that match this <code>regex</code> pattern</label>
               <div class="form-text">

--- a/options.html
+++ b/options.html
@@ -159,7 +159,7 @@
           </div>
           <div class="d-flex gap-2 mb-3">
           </div>
-          <div id="entriesList" class="list-group"></div>
+          <div id="snapshotsList" class="list-group"></div>
         </div>
         
         <div class="col-md-2">
@@ -190,7 +190,7 @@
               </div>
             </div>
             <small class="text-muted">
-              Selected entries: <span id="selectedUrlCountModal">0</span>
+              Selected snapshots: <span id="selectedUrlCountModal">0</span>
             </small>
           </div>
           <div class="modal-footer">
@@ -513,7 +513,7 @@ archivebox config --set <a href="https://github.com/ArchiveBox/ArchiveBox/wiki/C
   <script src="bootstrap.bundle.min.js"></script>
   <link rel="stylesheet" href="bootstrap-icons.css">
   <!-- <script type="module" src="options.js"></script> -->
-  <!-- <script type="module" src="entries-tab.js"></script>
+  <!-- <script type="module" src="snapshots-tab.js"></script>
   <script type="module" src="import-tab.js"></script>
   <script type="module" src="personas-tab.js"></script>
   <script type="module" src="cookies-tab.js"></script> -->

--- a/options.js
+++ b/options.js
@@ -1,4 +1,4 @@
-import { initializeEntriesTab } from './entries-tab.js';
+import { initializeSnapshotsTab } from './snapshots-tab.js';
 import { initializeImport } from './import-tab.js';
 import { initializePersonasTab } from './personas-tab.js';
 import { initializeCookiesTab } from './cookies-tab.js';
@@ -6,7 +6,7 @@ import { initializeConfigTab } from './config-tab.js';
 
 // Initialize all tabs when options page loads
 document.addEventListener('DOMContentLoaded', () => {
-  initializeEntriesTab();
+  initializeSnapshotsTab();
   initializeImport();
   initializePersonasTab();
   initializeCookiesTab();

--- a/popup.js
+++ b/popup.js
@@ -45,7 +45,7 @@ async function sendToArchiveBox(url, tags) {
         type: 'archivebox_add',
         body: JSON.stringify({
           urls: [url],
-          tags: tags.join(','),
+          tags: tags,
         })
       }, (response) => {
         if (!response.ok) {

--- a/popup.js
+++ b/popup.js
@@ -9,7 +9,7 @@ window.hide_timer = null;
 window.closePopup = function () {
   document.querySelector(".archive-box-iframe")?.remove();
   window.popup_element = null;
-  console.log("i Closed popup.");
+  console.debug("Closed ArchiveBox popup");
 };
 
 // Handle escape key when popup doesn't have focus

--- a/popup.js
+++ b/popup.js
@@ -79,12 +79,6 @@ window.getCurrentSnapshot = async function() {
     snapshots.push(current_snapshot);
     await chrome.storage.local.set({ entries: snapshots });
   }
-  current_snapshot.id = current_snapshot.id || crypto.randomUUID();
-  current_snapshot.url = current_snapshot.url || window.location.href;
-  current_snapshot.timestamp = current_snapshot.timestamp || new Date().toISOString();
-  current_snapshot.tags = current_snapshot.tags || [];
-  current_snapshot.title = current_snapshot.title || document.title;
-  current_snapshot.notes = current_snapshot.notes || '';
 
   console.log('i Loaded current ArchiveBox snapshot', current_snapshot);
   return { current_snapshot, snapshots };  // Return both for atomic updates

--- a/popup.js
+++ b/popup.js
@@ -9,10 +9,10 @@ window.hide_timer = null;
 window.closePopup = function () {
   document.querySelector(".archive-box-iframe")?.remove();
   window.popup_element = null;
-  console.log("close popup");
+  console.log("i Closed popup.");
 };
 
-// handle escape key when popup doesn't have focus
+// Handle escape key when popup doesn't have focus
 document.addEventListener('keydown', (e) => {
   if (e.key == 'Escape') {
     closePopup();
@@ -31,16 +31,13 @@ async function sendToArchiveBox(url, tags) {
 
   try {
     console.log('i Sending to ArchiveBox', { url, tags });
-
-    const addCommandArgs = JSON.stringify({
-      urls: [url],
-      tags: tags.join(','),
-    });
-
-    const addResponse = await new Promise((resolve, reject) => {
+    await new Promise((resolve, reject) => {
       chrome.runtime.sendMessage({
         type: 'archivebox_add',
-        body: addCommandArgs
+        body: JSON.stringify({
+          urls: [url],
+          tags: tags.join(','),
+        })
       }, (response) => {
         if (!response.ok) {
           reject(`${response.errorMessage}`);
@@ -62,7 +59,6 @@ async function sendToArchiveBox(url, tags) {
     <span class="status-indicator ${ok ? 'success' : 'error'}"></span>
     ${status}
   `;
-  return { ok: ok, status: status};
 }
 
 window.getCurrentEntry = async function() {

--- a/snapshots-tab.js
+++ b/snapshots-tab.js
@@ -560,7 +560,7 @@ export function initializeSnapshotsTab() {
       // Send to ArchiveBox
       let success = true, status = 'success';
       try {
-        await addToArchiveBox([item.url], item.tags.join(','));
+        await addToArchiveBox([item.url], item.tags);
         success = true;
         status = 'success';
       } catch (error) {

--- a/snapshots-tab.js
+++ b/snapshots-tab.js
@@ -1,34 +1,34 @@
-import { filterEntries, addToArchiveBox, downloadCsv, downloadJson, updateStatusIndicator, getArchiveBoxServerUrl } from './utils.js';
+import { filterSnapshots, addToArchiveBox, downloadCsv, downloadJson, updateStatusIndicator, getArchiveBoxServerUrl } from './utils.js';
 
-export async function renderEntries(filterText = '', tagFilter = '') {
-  const { entries = [] } = await chrome.storage.local.get('entries');
+export async function renderSnapshots(filterText = '', tagFilter = '') {
+  const { snapshots = [] } = await chrome.storage.local.get('snapshots');
   
   if (!window.location.search.includes(filterText)) {
     window.history.pushState({}, '', `?search=${filterText}`);
   }
 
   // Apply filters
-  let filteredEntries = entries;
+  let filteredSnapshots = snapshots;
   if (tagFilter) {
-    filteredEntries = entries.filter(entry => entry.tags.includes(tagFilter));
+    filteredSnapshots = snapshots.filter(snapshot => snapshot.tags.includes(tagFilter));
   }
-  filteredEntries = filterEntries(filteredEntries, filterText);
+  filteredSnapshots = filterSnapshots(filteredSnapshots, filterText);
 
-  // Display filtered entries
-  const entriesList = document.getElementById('entriesList');
-  entriesList.innerHTML = filteredEntries.map(entry => `
+  // Display filtered snapshots
+  const snapshotsList = document.getElementById('snapshotsList');
+  snapshotsList.innerHTML = filteredSnapshots.map(snapshot => `
     <div class="list-group-item">
       <div class="row">
         <small class="col-lg-2" style="display: block;">
-          ${new Date(entry.timestamp).toISOString().replace('T', ' ').split('.')[0]}
+          ${new Date(snapshot.timestamp).toISOString().replace('T', ' ').split('.')[0]}
         </small>
         <h5 class="col-lg-7">
-          <a href="${entry.url}" target="_blank" name="${entry.id}" id="${entry.id}"><img src="${entry.favicon}" class="favicon"/><code>${entry.url}</code></a>
+          <a href="${snapshot.url}" target="_blank" name="${snapshot.id}" id="${snapshot.id}"><img src="${snapshot.favicon}" class="favicon"/><code>${snapshot.url}</code></a>
         </h5>
         <div class="col-lg-3">
-          ${entry.tags.length ? `
+          ${snapshot.tags.length ? `
             <p class="mb-1">
-              ${entry.tags.map(tag => 
+              ${snapshot.tags.map(tag => 
                 `<span class="badge bg-secondary me-1 tag-filter" role="button" data-tag="${tag}">${tag}</span>`
               ).join('')}
             </p>
@@ -44,13 +44,13 @@ export async function renderEntries(filterText = '', tagFilter = '') {
       const tagText = tag.dataset.tag;
       const filterInput = document.getElementById('filterInput');
       filterInput.value = tagText;
-      renderEntries(tagText);
+      renderSnapshots(tagText);
     });
   });
 }
 
-export function initializeEntriesTab() {
-  let selectedEntries = new Set();
+export function initializeSnapshotsTab() {
+  let selectedSnapshots = new Set();
   let filteredTags = [];
   let selectedTagIndex = -1;
 
@@ -153,28 +153,28 @@ export function initializeEntriesTab() {
 
     // Save changes button
     document.getElementById('saveTagChanges').addEventListener('click', async () => {
-      const { entries = [] } = await chrome.storage.local.get('entries');
+      const { snapshots = [] } = await chrome.storage.local.get('snapshots');
       const newTags = getCurrentModalTags();
       
-      // Update tags for all selected entries
-      entries.forEach(entry => {
-        if (selectedEntries.has(entry.id)) {
-          entry.tags = [...newTags];
+      // Update tags for all selected snapshots
+      snapshots.forEach(snapshot => {
+        if (selectedSnapshots.has(snapshot.id)) {
+          snapshot.tags = [...newTags];
         }
       });
       
-      await chrome.storage.local.set({ entries });
+      await chrome.storage.local.set({ snapshots });
       
       // Close modal and refresh view
       const modalInstance = bootstrap.Modal.getInstance(modal);
       modalInstance.hide();
-      await renderEntries();
+      await renderSnapshots();
     });
   }
 
   async function getAllUniqueTags() {
-    const { entries = [] } = await chrome.storage.local.get('entries');
-    return [...new Set(entries.flatMap(entry => entry.tags))]
+    const { snapshots = [] } = await chrome.storage.local.get('snapshots');
+    return [...new Set(snapshots.flatMap(snapshot => snapshot.tags))]
       .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
   }
 
@@ -193,13 +193,13 @@ export function initializeEntriesTab() {
   }
 
   async function updateCurrentTagsList() {
-    const { entries = [] } = await chrome.storage.local.get('entries');
-    const selectedEntriesArray = entries.filter(e => selectedEntries.has(e.id));
+    const { snapshots = [] } = await chrome.storage.local.get('snapshots');
+    const selectedSnapshotsArray = snapshots.filter(e => selectedSnapshots.has(e.id));
     
-    // Get tags that exist in ALL selected entries
-    const commonTags = selectedEntriesArray.reduce((acc, entry) => {
-      if (!acc) return new Set(entry.tags);
-      return new Set([...acc].filter(tag => entry.tags.includes(tag)));
+    // Get tags that exist in ALL selected snapshots
+    const commonTags = selectedSnapshotsArray.reduce((acc, snapshot) => {
+      if (!acc) return new Set(snapshot.tags);
+      return new Set([...acc].filter(tag => snapshot.tags.includes(tag)));
     }, null);
 
     const tagsList = document.getElementById('currentTagsList');
@@ -236,7 +236,7 @@ export function initializeEntriesTab() {
   }
 
   function updateSelectionCount() {
-    const count = selectedEntries.size;
+    const count = selectedSnapshots.size;
     // Update count in main view
     document.getElementById('selectedUrlCount').textContent = count;
     // Update count in modal
@@ -244,7 +244,7 @@ export function initializeEntriesTab() {
   }
 
   function updateActionButtonStates() {
-    const hasSelection = selectedEntries.size > 0;
+    const hasSelection = selectedSnapshots.size > 0;
     
     // Update all action buttons based on selection state
     [
@@ -267,30 +267,30 @@ export function initializeEntriesTab() {
   const selectAllCheckbox = document.getElementById('selectAllUrls');
   if (selectAllCheckbox) {
     selectAllCheckbox.addEventListener('click', async () => {
-      const { entries = [] } = await chrome.storage.local.get('entries');
+      const { snapshots = [] } = await chrome.storage.local.get('snapshots');
       const filterText = document.getElementById('filterInput').value.toLowerCase();
       
-      // Get currently filtered entries
-      const filteredEntries = filterEntries(entries, filterText);
+      // Get currently filtered snapshots
+      const filteredSnapshots = filterSnapshots(snapshots, filterText);
 
-      // If all filtered entries are selected, deselect all
-      const allFilteredSelected = filteredEntries.every(entry => 
-        selectedEntries.has(entry.id)
+      // If all filtered snapshots are selected, deselect all
+      const allFilteredSelected = filteredSnapshots.every(snapshot => 
+        selectedSnapshots.has(snapshot.id)
       );
 
       if (allFilteredSelected) {
-        // Deselect only the filtered entries
-        filteredEntries.forEach(entry => {
-          selectedEntries.delete(entry.id);
+        // Deselect only the filtered snapshots
+        filteredSnapshots.forEach(snapshot => {
+          selectedSnapshots.delete(snapshot.id);
         });
       } else {
-        // Select all filtered entries
-        filteredEntries.forEach(entry => {
-          selectedEntries.add(entry.id);
+        // Select all filtered snapshot
+        filteredSnapshots.forEach(snapshot => {
+          selectedSnapshots.add(snapshot.id);
         });
       }
 
-      await renderEntries();
+      await renderSnapshots();
     });
   }
 
@@ -298,18 +298,18 @@ export function initializeEntriesTab() {
   const deselectAllButton = document.getElementById('deselectAllUrls');
   if (deselectAllButton) {
     deselectAllButton.addEventListener('click', () => {
-      selectedEntries.clear();
-      renderEntries();
+      selectedSnapshots.clear();
+      renderSnapshots();
     });
   }
 
   // Add handler for individual checkbox changes
-  document.getElementById('entriesList').addEventListener('change', (e) => {
-    if (e.target.classList.contains('entry-checkbox')) {
+  document.getElementById('snapshotsList').addEventListener('change', (e) => {
+    if (e.target.classList.contains('snapshot-checkbox')) {
       if (e.target.checked) {
-        selectedEntries.add(e.target.value);
+        selectedSnapshots.add(e.target.value);
       } else {
-        selectedEntries.delete(e.target.value);
+        selectedSnapshots.delete(e.target.value);
       }
       updateSelectionCount();
       updateActionButtonStates();
@@ -330,12 +330,12 @@ export function initializeEntriesTab() {
     window.history.pushState({}, '', newUrl);
   }
 
-  async function renderTagsList(filteredEntries) {
+  async function renderTagsList(filteredSnapshots) {
     const tagsList = document.getElementById('tagsList');
     
-    // Count occurrences of each tag in filtered entries only
-    const tagCounts = filteredEntries.reduce((acc, entry) => {
-      entry.tags.forEach(tag => {
+    // Count occurrences of each tag in filtered snapshots only
+    const tagCounts = filteredSnapshots.reduce((acc, snapshot) => {
+      snapshot.tags.forEach(tag => {
         acc[tag] = (acc[tag] || 0) + 1;
       });
       return acc;
@@ -375,67 +375,67 @@ export function initializeEntriesTab() {
           filterInput.value = tag;
         }
         
-        renderEntries();
+        renderSnapshots();
       });
     });
   }
 
-  // Modify existing renderEntries function
-  async function renderEntries() {
-    const { entries = [] } = await chrome.storage.local.get(['entries']);
+  // Modify existing renderSnapshots function
+  async function renderSnapshots() {
+    const { snapshots = [] } = await chrome.storage.local.get(['snapshots']);
     const archivebox_server_url = await getArchiveBoxServerUrl();
 
     const filterText = document.getElementById('filterInput').value.toLowerCase();
-    const entriesList = document.getElementById('entriesList');
+    const snapshotsList = document.getElementById('snapshotsList');
     
     // Update URL when filter changes
     updateFilterUrl(filterText);
     
-    // Filter entries based on search text
-    const filteredEntries = filterEntries(entries, filterText);
+    // Filter snapshots based on search text
+    const filteredSnapshots = filterSnapshots(snapshots, filterText);
 
-    // sort entries by timestamp, newest first
-    filteredEntries.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+    // sort snapshots by timestamp, newest first
+    filteredSnapshots.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
 
     // Add CSS for URL truncation if not already present
-    if (!document.getElementById('entriesListStyles')) {
+    if (!document.getElementById('snapshotsListStyles')) {
       const style = document.createElement('style');
-      style.id = 'entriesListStyles';
+      style.id = 'snapshotsListStyles';
       style.textContent = `
-        .entry-url {
+        .snapshot-url {
           max-width: 800px;
           white-space: nowrap;
           overflow: hidden;
           text-overflow: ellipsis;
           display: inline-block;
         }
-        .entry-title-line {
+        .snapshot-title-line {
           display: flex;
           align-items: center;
           justify-content: space-between;
           gap: 8px;
         }
-        .entry-title {
+        .snapshot-title {
           font-size: 0.9em;
           color: #666;
           margin-bottom: 4px;
         }
-        .entry-link-to-archivebox {
+        .snapshot-link-to-archivebox {
           font-size: 0.7em;
           color: #888;
           min-width: 330px;
         }
-        .entry-timestamp {
+        .snapshot-timestamp {
           font-size: 0.8em;
           color: #888;
           margin-left: 8px;
         }
-        .entry-content {
+        .snapshot-content {
           display: flex;
           flex-direction: column;
           gap: 2px;
         }
-        .entry-url-line {
+        .snapshot-url-line {
           display: flex;
           align-items: center;
           gap: 8px;
@@ -444,43 +444,43 @@ export function initializeEntriesTab() {
       document.head.appendChild(style);
     }
 
-    // Render entries list
-    entriesList.innerHTML = filteredEntries.map(entry => `
+    // Render snapshots list
+    snapshotsList.innerHTML = filteredSnapshots.map(snapshot => `
       <div class="list-group-item d-flex align-items-start gap-2">
         <input type="checkbox" 
-               class="entry-checkbox form-check-input mt-2" 
-               value="${entry.id}"
-               ${selectedEntries.has(entry.id) ? 'checked' : ''}>
-        <div class="entry-content flex-grow-1">
-          <div class="entry-title-line">
-            <div class="entry-title">${entry.title || 'Untitled'}</div>
+               class="snapshot-checkbox form-check-input mt-2" 
+               value="${snapshot.id}"
+               ${selectedSnapshots.has(snapshot.id) ? 'checked' : ''}>
+        <div class="snapshot-content flex-grow-1">
+          <div class="snapshot-title-line">
+            <div class="snapshot-title">${snapshot.title || 'Untitled'}</div>
             ${(()=>{
               return archivebox_server_url ?
-                `<div class="entry-link-to-archivebox btn-group" role="group">
-                   <a href=${entry.url} target="_blank" class="btn btn-sm btn-outline-primary">
+                `<div class="snapshot-link-to-archivebox btn-group" role="group">
+                   <a href=${snapshot.url} target="_blank" class="btn btn-sm btn-outline-primary">
                      🔗 Original
                    </a>
-                   <a href=${archivebox_server_url}/archive/${entry.url} target="_blank" class="btn btn-sm btn-outline-primary">
+                   <a href=${archivebox_server_url}/archive/${snapshot.url} target="_blank" class="btn btn-sm btn-outline-primary">
                      📦 ArchiveBox
                    </a>
-                   <a href="https://web.archive.org/web/${entry.url}" target="_blank" class="btn btn-sm btn-outline-primary">
+                   <a href="https://web.archive.org/web/${snapshot.url}" target="_blank" class="btn btn-sm btn-outline-primary">
                      🏛️ Archive.org
                    </a>
                  </div>`
                 : '' })()
             }
           </div>
-          <div class="entry-url-line">
-            <img class="favicon" src="${entry.favicon || '128.png'}"
+          <div class="snapshot-url-line">
+            <img class="favicon" src="${snapshot.favicon || '128.png'}"
                  onerror="this.src='128.png'"
                  width="16" height="16">
-            <code class="entry-url">${entry.url}</code>
-            <span class="entry-timestamp">
-              ${new Date(entry.timestamp).toLocaleString()}
+            <code class="snapshot-url">${snapshot.url}</code>
+            <span class="snapshot-timestamp">
+              ${new Date(snapshot.timestamp).toLocaleString()}
             </span>
           </div>
           <div class="small text-muted mt-1">
-            ${entry.tags.map(tag => 
+            ${snapshot.tags.map(tag => 
               `<span class="badge bg-secondary me-1">${tag}</span>`
             ).join('')}
           </div>
@@ -492,8 +492,8 @@ export function initializeEntriesTab() {
     updateSelectionCount();
     updateActionButtonStates();
 
-    // Update tags list with filtered entries
-    await renderTagsList(filteredEntries);
+    // Update tags list with filtered snapshots
+    await renderTagsList(filteredSnapshots);
   }
 
   // Initialize filter input with URL parameter and trigger initial render
@@ -505,29 +505,29 @@ export function initializeEntriesTab() {
   filterInput.addEventListener('input', () => {
     clearTimeout(filterTimeout);
     filterTimeout = setTimeout(() => {
-      renderEntries();
+      renderSnapshots();
     }, 300);
   });
 
   // Handle browser back/forward
   window.addEventListener('popstate', () => {
     filterInput.value = getInitialFilter();
-    renderEntries();
+    renderSnapshots();
   });
 
-  // Initialize the tag modal when the entries tab is initialized
+  // Initialize the tag modal when the snapshots tab is initialized
   initializeTagModal();
 
   // Initial render
-  renderEntries();
+  renderSnapshots();
 
   // Export to CSV
   document.getElementById('downloadCsv').addEventListener('click', async () => {
-    const { entries = [] } = await chrome.storage.local.get('entries');
-    const selectedItems = entries.filter(e => selectedEntries.has(e.id));
+    const { snapshots = [] } = await chrome.storage.local.get('snapshots');
+    const selectedItems = snapshots.filter(e => selectedSnapshots.has(e.id));
     
     if (!selectedItems.length) {
-      alert('No entries selected');
+      alert('No snapshots selected');
       return;
     }
 
@@ -536,44 +536,44 @@ export function initializeEntriesTab() {
 
   // Export to JSON
   document.getElementById('downloadJson').addEventListener('click', async () => {
-    const { entries = [] } = await chrome.storage.local.get('entries');
-    const selectedItems = entries.filter(e => selectedEntries.has(e.id));
+    const { snapshots = [] } = await chrome.storage.local.get('snapshots');
+    const selectedItems = snapshots.filter(e => selectedSnapshots.has(e.id));
     
     if (!selectedItems.length) {
-      alert('No entries selected');
+      alert('No snapshots selected');
       return;
     }
 
     downloadJson(selectedItems);
   });
 
-  // Delete entries
+  // Delete snapshots
   document.getElementById('deleteFiltered').addEventListener('click', async () => {
-    const { entries = [] } = await chrome.storage.local.get('entries');
-    const selectedItems = entries.filter(e => selectedEntries.has(e.id));
+    const { snapshots = [] } = await chrome.storage.local.get('snapshots');
+    const selectedItems = snapshots.filter(e => selectedSnapshots.has(e.id));
     console.log(`deleting ${selectedItems.length} items from local storage`)
 
     if (!selectedItems.length) {
-      alert('No entries to delete');
+      alert('No snapshots to delete');
       return;
     }
 
-    const message = `Delete ${selectedItems.length} entries?`
+    const message = `Delete ${selectedItems.length} snapshots?`
 
     if (!confirm(message)) return;
 
     const idsToDelete = new Set(selectedItems.map(e => e.id));
-    const remainingEntries = entries.filter(e => !idsToDelete.has(e.id));
-    await chrome.storage.local.set({ entries: remainingEntries });
+    const remainingSnapshots = snapshots.filter(e => !idsToDelete.has(e.id));
+    await chrome.storage.local.set({ snapshots: remainingSnapshots });
 
     // Refresh the view
-    await renderEntries('');
+    await renderSnapshots('');
   });
 
-  // Sync entries
+  // Sync snapshots
   document.getElementById('syncFiltered').addEventListener('click', async () => {
-    const { entries = [] } = await chrome.storage.local.get('entries');
-    const selectedItems = entries.filter(e => selectedEntries.has(e.id));
+    const { snapshots = [] } = await chrome.storage.local.get('snapshots');
+    const selectedItems = snapshots.filter(e => selectedSnapshots.has(e.id));
     console.log(`syncing ${selectedItems.length} items to ArchiveBox server`)
 
     if (!selectedItems.length) {
@@ -589,15 +589,15 @@ export function initializeEntriesTab() {
     for (const item of selectedItems) {
       const row = document.querySelector(`input[value="${item.id}"]`);
       if (!row) continue;
-      const entryTitle = row.parentElement.querySelector('.entry-title');
+      const snapshot = row.parentElement.querySelector('.snapshot-title');
 
       // Add status indicator if it doesn't exist
-      let statusIndicator = entryTitle.querySelector('.sync-status');
+      let statusIndicator = snapshot.querySelector('.sync-status');
       if (!statusIndicator) {
         statusIndicator = document.createElement('span');
         statusIndicator.className = 'sync-status status-indicator';
         statusIndicator.style.marginLeft = '10px';
-        entryTitle.appendChild(statusIndicator);
+        snapshot.appendChild(statusIndicator);
       }
 
       // Update status to "in progress"

--- a/snapshots-tab.js
+++ b/snapshots-tab.js
@@ -422,7 +422,7 @@ export function initializeSnapshotsTab() {
             }
           </div>
           <div class="snapshot-url-line">
-            <img class="favicon" src="${snapshot.favicon || '128.png'}"
+            <img class="favicon" src="${snapshot.favIconUrl || '128.png'}"
                  onerror="this.src='128.png'"
                  width="16" height="16">
             <code class="snapshot-url">${snapshot.url}</code>

--- a/utils.js
+++ b/utils.js
@@ -40,7 +40,14 @@ export function updateStatusIndicator(indicator, textElement, success, message) 
   textElement.className = success ? 'text-success' : 'text-danger';
 }
 
-export async function addToArchiveBox(addCommandArgs, onComplete, onError) {
+/**
+ * Adds URLs to ArchiveBox using the modern API (v0.8.0+) or falls back to legacy API.
+ * The tags string should be comma-separated.
+ * @param {string} addCommandArgs - JSON string with {urls: string[], tags: string}
+ * @param {function({ok: boolean, status: number, statusText: string})} onComplete
+ * @param {function({ok: false, errorMessage: string})} onError
+ */
+ export async function addToArchiveBox(addCommandArgs, onComplete, onError) {
   console.log('i addToArchiveBox', addCommandArgs);
   try {
     const archivebox_server_url = await getArchiveBoxServerUrl();
@@ -66,7 +73,6 @@ export async function addToArchiveBox(addCommandArgs, onComplete, onError) {
         if (response.ok) {
           console.log('i addToArchiveBox using v0.8.5 REST API succeeded', response.status, response.statusText);
           onComplete({ok: response.ok, status: response.status, statusText: response.statusText});
-          return true;
         } else {
           console.warn(`! addToArchiveBox using v0.8.5 REST API failed with status ${response.status} ${response.statusText}`);
           // Fall through to legacy API
@@ -114,8 +120,6 @@ export async function addToArchiveBox(addCommandArgs, onComplete, onError) {
     console.error('! addToArchiveBox failed', e.message);
     onError({ok: false, errorMessage: e.message});
   }
-
-  return true;
 }
 
 export function downloadCsv(entries) {

--- a/utils.js
+++ b/utils.js
@@ -1,13 +1,13 @@
 // Common utility functions
 
 export class Snapshot {
-  constructor(url, tags, title, favIconUrl) {
+  constructor(url, tags = [], title = '', favIconUrl = null) {
     this.id = crypto.randomUUID();
     this.url = url;
     this.timestamp = new Date().toISOString();
     this.tags = tags;
     this.title = title;
-    this.favicon = favIconUrl;
+    this.favIconUrl = favIconUrl;
   }
 }
 
@@ -103,7 +103,7 @@ export async function addToArchiveBox(urls, tags, depth = 0, update = false, upd
 }
 
 export function downloadCsv(snapshots) {
-  const headers = ['id', 'timestamp', 'url', 'title', 'tags', 'notes'];
+  const headers = ['id', 'timestamp', 'url', 'title', 'tags'];
   const csvRows = [
     headers.join(','),
     ...snapshots.map(snapshot => {
@@ -113,7 +113,6 @@ export function downloadCsv(snapshots) {
         `"${snapshot.url}"`,
         `"${snapshot.title || ''}"`,
         `"${snapshot.tags.join(';')}"`,
-        `"${snapshot.notes || ''}"`
       ].join(',');
     })
   ];

--- a/utils.js
+++ b/utils.js
@@ -51,8 +51,9 @@ export function updateStatusIndicator(indicator, textElement, success, message) 
   textElement.className = success ? 'text-success' : 'text-danger';
 }
 
-export async function addToArchiveBox(urls, tags, depth = 0, update = false, update_all = false) {
-  console.log(`i Adding urls ${urls} and tags ${tags} to ArchiveBox`);
+export async function addToArchiveBox(urls, tags = [], depth = 0, update = false, update_all = false) {
+  const formattedTags = tags.join(',');
+  console.log(`i Adding urls ${urls} and tags ${formattedTags} to ArchiveBox`);
 
   const archivebox_server_url = await getArchiveBoxServerUrl();
   const { archivebox_api_key } = await chrome.storage.local.get(['archivebox_api_key']);
@@ -71,7 +72,7 @@ export async function addToArchiveBox(urls, tags, depth = 0, update = false, upd
       },
       method: 'post',
       credentials: 'include',
-      body: JSON.stringify({ urls, tags, depth, update, update_all })
+      body: JSON.stringify({ urls, formattedTags, depth, update, update_all })
     });
 
     if (response.ok) {
@@ -87,7 +88,7 @@ export async function addToArchiveBox(urls, tags, depth = 0, update = false, upd
 
   const body = new FormData();
   body.append("url", urls.join("\n"));
-  body.append("tag", tags);
+  body.append("tag", formattedTags);
   body.append("parser", "auto")
   body.append("depth", depth)
 

--- a/utils.js
+++ b/utils.js
@@ -1,5 +1,16 @@
 // Common utility functions
 
+export class Snapshot {
+  constructor(url, tags, title, favIconUrl) {
+    this.id = crypto.randomUUID();
+    this.url = url;
+    this.timestamp = new Date().toISOString();
+    this.tags = tags;
+    this.title = title;
+    this.favicon = favIconUrl;
+  }
+}
+
 // Helper to get server URL with fallback to legacy config name
 export async function getArchiveBoxServerUrl() {
   const { archivebox_server_url } = await chrome.storage.local.get(['archivebox_server_url']);    // new ArchiveBox Extension v2.1.3 location

--- a/utils.js
+++ b/utils.js
@@ -51,6 +51,7 @@ export function updateStatusIndicator(indicator, textElement, success, message) 
   textElement.className = success ? 'text-success' : 'text-danger';
 }
 
+// Archive URLs on the configured ArchiveBox server instance.
 export async function addToArchiveBox(urls, tags = [], depth = 0, update = false, update_all = false) {
   const formattedTags = tags.join(',');
   console.log(`i Adding urls ${urls} and tags ${formattedTags} to ArchiveBox`);

--- a/utils.js
+++ b/utils.js
@@ -7,17 +7,17 @@ export async function getArchiveBoxServerUrl() {
   return archivebox_server_url || config_archiveBoxBaseUrl || '';
 }
 
-export function filterEntries(entries, filterText) {
-  if (!filterText) return entries;
+export function filterSnapshots(snapshots, filterText) {
+  if (!filterText) return snapshots;
   
   const searchTerms = filterText.toLowerCase().split(' ');
-  return entries.filter(entry => {
+  return snapshots.filter(snapshot => {
     const searchableText = [
-      entry.url,
-      entry.title,
-      entry.id,
-      new Date(entry.timestamp).toISOString(),
-      ...entry.tags
+      snapshot.url,
+      snapshot.title,
+      snapshot.id,
+      new Date(snapshot.timestamp).toISOString(),
+      ...snapshot.tags
     ].join(' ').toLowerCase();
     
     return searchTerms.every(term => searchableText.includes(term));
@@ -91,18 +91,18 @@ export async function addToArchiveBox(urls, tags, depth = 0, update = false, upd
   }
 }
 
-export function downloadCsv(entries) {
+export function downloadCsv(snapshots) {
   const headers = ['id', 'timestamp', 'url', 'title', 'tags', 'notes'];
   const csvRows = [
     headers.join(','),
-    ...entries.map(entry => {
+    ...snapshots.map(snapshot => {
       return [
-        entry.id,
-        entry.timestamp,
-        `"${entry.url}"`,
-        `"${entry.title || ''}"`,
-        `"${entry.tags.join(';')}"`,
-        `"${entry.notes || ''}"` 
+        snapshot.id,
+        snapshot.timestamp,
+        `"${snapshot.url}"`,
+        `"${snapshot.title || ''}"`,
+        `"${snapshot.tags.join(';')}"`,
+        `"${snapshot.notes || ''}"`
       ].join(',');
     })
   ];
@@ -118,8 +118,8 @@ export function downloadCsv(entries) {
   document.body.removeChild(link);
 }
 
-export function downloadJson(entries) {
-  const jsonContent = JSON.stringify(entries, null, 2);
+export function downloadJson(snapshots) {
+  const jsonContent = JSON.stringify(snapshots, null, 2);
   const blob = new Blob([jsonContent], { type: 'application/json;charset=utf-8;' });
   const url = URL.createObjectURL(blob);
   const link = document.createElement('a');


### PR DESCRIPTION
This makes the auto-archiving regex fields in the configuration page functional.

If the user has enabled auto-archiving, granted the requested permissions, and entered a regex, upon navigating to a new tab, a page with a matching URL (that doesn't match the exclude regex) will be automatically sent to the ArchiveBox server for archiving.

Also, the addToArchiveBox function is simplified while maintaining the same logic, and it looked like syncToArchiveBox was extraneous and didn't handle the fallback logic if the user was using an older version of ArchiveBox, so it was removed.