### PR TITLE
Add data collection permissions to manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -58,7 +58,16 @@
   },
   "browser_specific_settings": {
     "gecko": {
-      "id": "archivebox@example.com"
+      "id": "archivebox@example.com",
+      "data_collection_permissions": {
+        "required": [
+          "browsingActivity"
+        ],
+        "optional": [
+          "bookmarksInfo",
+          "websiteContent"
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
By adding these settings, the extension can be published in addons.mozilla.org.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Firefox data collection permissions to manifest.json to declare required and optional data types and meet AMO review requirements. Required: browsingActivity. Optional: bookmarksInfo, websiteContent.

<sup>Written for commit af02a1d5769c94f3676a7bd80fdbfc662cdacf2a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

