### PR TITLE
Fix MHTML caputre dissapearing race condition

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -516,16 +516,21 @@ async function captureMhtml(tab: Browser.tabs.Tab, snapshot: Snapshot): Promise<
     throw new Error(t("MHTML capture is not available in this browser."));
   }
 
-  // Re-check the tab right before capturing: the user may have navigated to a
-  // non-capturable page or closed the tab while a previous step (permission
-  // prompt, screenshot scroll, server upload) was running. Capturing a stale or
-  // navigating tab is what produces "Cannot find the tab for this request".
+  // Re-check the tab right before capturing: the user may have navigated away
+  // (to the same-but-different or a non-capturable page) or closed the tab while
+  // a previous step (permission prompt, screenshot scroll, server upload) was
+  // running. Capturing a stale or navigating tab is what produces "Cannot find
+  // the tab for this request"; capturing a navigated tab would also save the
+  // wrong page's bytes under this snapshot's URL, so require the URL to match.
   const liveTab = await browser.tabs.get(tab.id).catch(() => null);
   if (!liveTab || typeof liveTab.id !== 'number') {
     throw new Error(t("The tab is no longer available for MHTML capture."));
   }
   if (!isArchiveablePageUrl(liveTab.url || '')) {
     throw new Error(t("This page cannot be captured as MHTML."));
+  }
+  if ((liveTab.url || '') !== snapshot.url) {
+    throw new Error(t("The tab navigated to a different page before MHTML capture."));
   }
   if (liveTab.status && liveTab.status !== 'complete') {
     throw new Error(t("The tab is still loading and cannot be captured yet."));
@@ -551,7 +556,7 @@ async function captureMhtml(tab: Browser.tabs.Tab, snapshot: Snapshot): Promise<
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
     if (attempt > 0) {
       const stillThere = await browser.tabs.get(tabId).catch(() => null);
-      if (!stillThere || !isArchiveablePageUrl(stillThere.url || '')) {
+      if (!stillThere || (stillThere.url || '') !== snapshot.url || !isArchiveablePageUrl(stillThere.url || '')) {
         throw new Error(t("The tab is no longer available for MHTML capture."));
       }
     }

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,4 +1,4 @@
-import { addToArchiveBox, archiveBoxServerUrlMatches, archiveBoxSnapshotUrl, isConfiguredArchiveBoxUrl, removeFromArchiveBox, syncArchiveBoxSnapshotMetadata, testApiKey, testServerUrl } from '@/src/lib/archivebox';
+import { addToArchiveBox, archiveBoxServerUrlMatches, archiveBoxSnapshotUrl, isArchiveablePageUrl, isConfiguredArchiveBoxUrl, removeFromArchiveBox, syncArchiveBoxSnapshotMetadata, testApiKey, testServerUrl } from '@/src/lib/archivebox';
 import { uploadSnapshotCaptureArtifactsToArchiveBox } from '@/src/lib/archiveboxArtifacts';
 import { defaultSingleFileExtensionId, mhtmlUnsupportedMessage, supportsMhtmlCapture } from '@/src/lib/browserCapabilities';
 import { setUiLanguage, t } from '@/src/lib/i18n';
@@ -516,27 +516,90 @@ async function captureMhtml(tab: Browser.tabs.Tab, snapshot: Snapshot): Promise<
     throw new Error(t("MHTML capture is not available in this browser."));
   }
 
-  let bytes: ArrayBuffer;
-  try {
-    bytes = await new Promise<ArrayBuffer>((resolve, reject) => {
-      pageCapture.saveAsMHTML({ tabId: tab.id as number }, (mhtmlData) => {
-        const error = chromeLastError();
-        if (error) {
-          reject(new Error(`chrome.pageCapture.saveAsMHTML failed: ${error}`));
-          return;
-        }
-        if (!mhtmlData) {
-          reject(new Error(t("MHTML capture returned an empty file.")));
-          return;
-        }
-        blobToArrayBuffer(mhtmlData, t("generated MHTML data")).then(resolve, reject);
-      });
-    });
-  } catch (error) {
-    throw new Error(errorMessage(error));
+  // Re-check the tab right before capturing: the user may have navigated to a
+  // non-capturable page or closed the tab while a previous step (permission
+  // prompt, screenshot scroll, server upload) was running. Capturing a stale or
+  // navigating tab is what produces "Cannot find the tab for this request".
+  const liveTab = await browser.tabs.get(tab.id).catch(() => null);
+  if (!liveTab || typeof liveTab.id !== 'number') {
+    throw new Error(t("The tab is no longer available for MHTML capture."));
+  }
+  if (!isArchiveablePageUrl(liveTab.url || '')) {
+    throw new Error(t("This page cannot be captured as MHTML."));
+  }
+  if (liveTab.status && liveTab.status !== 'complete') {
+    throw new Error(t("The tab is still loading and cannot be captured yet."));
   }
 
+  const tabId = liveTab.id;
+  // Root cause (traced empirically): chrome.pageCapture.saveAsMHTML
+  // intermittently hands an MV3 service worker a Blob whose backing temp file
+  // Chromium has already deleted. The Blob still reports the correct `size`
+  // (cached metadata), but every read method -- arrayBuffer(), Response(blob),
+  // FileReader, Response(blob.stream()) -- fails identically with "A requested
+  // file or directory could not be found" (surfaced through fetch as "Failed to
+  // fetch"), and the same Blob never becomes readable no matter how long we
+  // wait. It is independent of read method, read timing, and how long the page
+  // has been settled. Because the file is gone, the only recovery is to ask the
+  // browser for a brand new capture (fresh file). A re-capture reads cleanly, so
+  // retry the whole capture a few times on that specific transient failure.
+  // Captures are serialized (see saveAsMhtmlBytes) so two captures never run at
+  // once and tear down each other's temp file.
+  const maxAttempts = 3;
+  let bytes: ArrayBuffer | undefined;
+  let lastError: unknown;
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    if (attempt > 0) {
+      const stillThere = await browser.tabs.get(tabId).catch(() => null);
+      if (!stillThere || !isArchiveablePageUrl(stillThere.url || '')) {
+        throw new Error(t("The tab is no longer available for MHTML capture."));
+      }
+    }
+    try {
+      bytes = await saveAsMhtmlBytes(pageCapture, tabId);
+      break;
+    } catch (error) {
+      lastError = error;
+      if (!isTransientMhtmlReadError(error)) throw new Error(errorMessage(error));
+    }
+  }
+  if (!bytes) throw new Error(errorMessage(lastError));
+
   return writeSnapshotMhtmlBytes(snapshot, bytes);
+}
+
+// A failed read of a saveAsMHTML Blob whose backing temp file vanished. These
+// are recoverable by re-capturing; other errors (permission, missing tab) are
+// not, so we must not retry those.
+function isTransientMhtmlReadError(error: unknown): boolean {
+  const message = errorMessage(error).toLowerCase();
+  return message.includes('failed to fetch')
+    || message.includes('could not be found')
+    || message.includes('failed to read');
+}
+
+let mhtmlCaptureQueue: Promise<unknown> = Promise.resolve();
+
+// Reads one MHTML capture as bytes, serialized so concurrent captures (for
+// example an auto-archive on page load overlapping a manual save) never run at
+// the same time and tear down each other's blob handle.
+function saveAsMhtmlBytes(pageCapture: ChromePageCaptureApi, tabId: number): Promise<ArrayBuffer> {
+  const run = mhtmlCaptureQueue.catch(() => undefined).then(() => new Promise<ArrayBuffer>((resolve, reject) => {
+    pageCapture.saveAsMHTML({ tabId }, (mhtmlData) => {
+      const error = chromeLastError();
+      if (error) {
+        reject(new Error(`chrome.pageCapture.saveAsMHTML failed: ${error}`));
+        return;
+      }
+      if (!mhtmlData) {
+        reject(new Error(t("MHTML capture returned an empty file.")));
+        return;
+      }
+      blobToArrayBuffer(mhtmlData, t("generated MHTML data")).then(resolve, reject);
+    });
+  }));
+  mhtmlCaptureQueue = run.catch(() => undefined);
+  return run;
 }
 
 type SingleFileCaptureResult = {
@@ -601,6 +664,7 @@ async function captureAndAttachSnapshotScreenshot(
     }
   }
   await attachScreenshotToSnapshot(snapshot.id, screenshot);
+  console.info(`ArchiveBox: saved screenshot for ${snapshot.url}`);
   return screenshot;
 }
 
@@ -624,6 +688,7 @@ async function captureAndAttachSnapshotMhtml(
   const mhtml = await captureMhtml(tab, snapshot);
   await attachMhtmlToSnapshot(snapshot.id, mhtml);
   snapshot.mhtml = mhtml;
+  console.info(`ArchiveBox: saved MHTML for ${snapshot.url}`);
   return mhtml;
 }
 
@@ -634,6 +699,7 @@ async function captureAndAttachSnapshotSingleFile(
   const singlefile = await captureSingleFileHtml(tab, snapshot);
   await attachSingleFileToSnapshot(snapshot.id, singlefile);
   snapshot.singlefile = singlefile;
+  console.info(`ArchiveBox: saved SingleFile HTML for ${snapshot.url}`);
   return singlefile;
 }
 
@@ -719,6 +785,7 @@ async function ensureSnapshotForTab(tab: Browser.tabs.Tab): Promise<{
 
 async function shouldAutoArchive(url: string): Promise<boolean> {
   try {
+    if (!isArchiveablePageUrl(url)) return false;
     const { archivebox_server_url, enable_auto_archive, match_urls, exclude_urls } = await getConfig();
     if (!enable_auto_archive || !match_urls.trim()) return false;
     if (archiveBoxServerUrlMatches(archivebox_server_url, url)) return false;
@@ -762,12 +829,35 @@ async function uploadSyncedSnapshotArtifacts(snapshotId: string): Promise<void> 
   await uploadSnapshotCaptureArtifactsToArchiveBox(snapshot);
 }
 
+// Saves a snapshot to the configured ArchiveBox server, logging a single line
+// about whether it worked. When no server is configured the snapshot just stays
+// saved locally; that is a normal state, not an error worth crashing or logging
+// loudly, so we never throw out of here.
+async function syncSnapshotToServer(snapshot: Snapshot): Promise<boolean> {
+  const serverUrl = await getArchiveBoxServerUrl();
+  if (!serverUrl) {
+    console.info(`ArchiveBox: saved ${snapshot.url} locally (no ArchiveBox server configured)`);
+    return false;
+  }
+  try {
+    const archivebox = await addToArchiveBox([snapshot.url], snapshot.tags, snapshot.depth ?? 0, false, false, [snapshot.id], [snapshot.title]);
+    await markSnapshotSynced(snapshot.id, archivebox);
+    await uploadSyncedSnapshotArtifacts(snapshot.id);
+    console.info(`ArchiveBox: saved ${snapshot.url} to ArchiveBox server`);
+    return true;
+  } catch (error) {
+    console.warn(`ArchiveBox: could not save ${snapshot.url} to ArchiveBox server: ${errorMessage(error)}`);
+    return false;
+  }
+}
+
 async function autoArchive(
   _tabId: number,
   changeInfo: { status?: string },
   tab: Browser.tabs.Tab,
 ): Promise<void> {
   if (changeInfo.status !== 'complete' || !tab.url) return;
+  if (!isArchiveablePageUrl(tab.url)) return;
 
   const snapshots = await getSnapshots();
   if (snapshots.some((snapshot) => snapshot.url === tab.url)) return;
@@ -781,19 +871,12 @@ async function autoArchive(
   );
   snapshots.push(snapshot);
   await setSnapshots(snapshots);
+  console.info(`ArchiveBox: auto-archiving ${snapshot.url}`);
 
-  const capturePromise = captureConfiguredSnapshotArtifacts(tab, snapshot, true).catch((error) => {
+  await captureConfiguredSnapshotArtifacts(tab, snapshot, true).catch((error) => {
     console.error(`Failed to capture local artifacts for ${snapshot.url}:`, error);
   });
-
-  try {
-    const archivebox = await addToArchiveBox([snapshot.url], snapshot.tags, snapshot.depth ?? 0, false, false, [snapshot.id], [snapshot.title]);
-    await markSnapshotSynced(snapshot.id, archivebox);
-    await capturePromise;
-    await uploadSyncedSnapshotArtifacts(snapshot.id);
-  } catch (error) {
-    console.error(`Failed to automatically archive ${snapshot.url}:`, error);
-  }
+  await syncSnapshotToServer(snapshot);
 }
 
 async function configureAutoArchiving(): Promise<void> {
@@ -812,13 +895,13 @@ async function configureAutoArchiving(): Promise<void> {
 
 async function saveTab(tab?: Browser.tabs.Tab): Promise<void> {
   if (!tab?.id || !tab.url) return;
+  if (!isArchiveablePageUrl(tab.url)) return;
   if (await isConfiguredArchiveBoxUrl(tab.url)) return;
+  console.info(`ArchiveBox: saving ${tab.url}`);
   try {
     const { snapshot, created } = await ensureSnapshotForTab(tab);
     await captureConfiguredSnapshotArtifacts(tab, snapshot, created);
-    const archivebox = await addToArchiveBox([snapshot.url], snapshot.tags, snapshot.depth ?? 0, false, false, [snapshot.id], [snapshot.title]);
-    await markSnapshotSynced(snapshot.id, archivebox);
-    await uploadSyncedSnapshotArtifacts(snapshot.id);
+    await syncSnapshotToServer(snapshot);
   } catch (error) {
     console.error('Failed to save tab to ArchiveBox:', error);
   }

--- a/entrypoints/popup/main.tsx
+++ b/entrypoints/popup/main.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import ReactDOM from 'react-dom/client';
 import { TagChip, TagInputChip, TagList } from '@/src/components/Tags';
-import { archiveBoxServerUrlMatches, hasServerHostPermission, requestServerHostPermission, syncArchiveBoxSnapshotMetadata, syncArchiveBoxSnapshotTags } from '@/src/lib/archivebox';
+import { archiveBoxServerUrlMatches, hasServerHostPermission, isArchiveablePageUrl, requestServerHostPermission, syncArchiveBoxSnapshotMetadata, syncArchiveBoxSnapshotTags } from '@/src/lib/archivebox';
 import { uploadSnapshotCaptureArtifactsToArchiveBox } from '@/src/lib/archiveboxArtifacts';
 import { mhtmlUnsupportedMessage, singleFileCaptureUnavailableMessage, singleFileChromeWebStoreUrl, supportsMhtmlCapture } from '@/src/lib/browserCapabilities';
 import { setUiLanguage, t } from '@/src/lib/i18n';
@@ -45,7 +45,7 @@ async function getActivePage(): Promise<ActivePage> {
   const { archivebox_server_url } = await getConfig();
   const extensionOrigin = browser.runtime.getURL('');
   const isOwnExtensionPage = (url = '') => url.startsWith(extensionOrigin);
-  const isArchiveablePage = (url = '') => /^(https?|file):/i.test(url) && !archiveBoxServerUrlMatches(archivebox_server_url, url);
+  const isArchiveablePage = (url = '') => isArchiveablePageUrl(url) && !archiveBoxServerUrlMatches(archivebox_server_url, url);
   const [activeTab] = await browser.tabs.query({ active: true, currentWindow: true });
   const tab = activeTab?.url && !isOwnExtensionPage(activeTab.url) && isArchiveablePage(activeTab.url)
     ? activeTab

--- a/entrypoints/popup/main.tsx
+++ b/entrypoints/popup/main.tsx
@@ -325,7 +325,6 @@ function ArchiveBoxOverlay() {
   }
 
   useEffect(() => {
-    console.info('ArchiveBox: opened save panel');
     getConfig()
       .then(({ ui_language, archivebox_server_url }) => {
         setUiLanguage(ui_language);

--- a/entrypoints/popup/main.tsx
+++ b/entrypoints/popup/main.tsx
@@ -310,6 +310,7 @@ function ArchiveBoxOverlay() {
       setRemoteStatus('archived');
       setRemoteDetail('');
       setStatus(t("Saved to ArchiveBox Server at depth $1", archiveDepth));
+      console.info(`ArchiveBox: saved ${url} to ArchiveBox server`);
       if (localSnapshotId) {
         await uploadCurrentArtifactsIfArchived(localSnapshotId);
       }
@@ -319,10 +320,12 @@ function ArchiveBoxOverlay() {
       setRemoteStatus('sync_failed');
       setRemoteDetail(errorMessage);
       setStatus(t("Saved locally. Failed to archive on server: $1", errorMessage));
+      console.warn(`ArchiveBox: could not save ${url} to ArchiveBox server: ${errorMessage}`);
     }
   }
 
   useEffect(() => {
+    console.info('ArchiveBox: opened save panel');
     getConfig()
       .then(({ ui_language, archivebox_server_url }) => {
         setUiLanguage(ui_language);

--- a/src/lib/archivebox.ts
+++ b/src/lib/archivebox.ts
@@ -1,9 +1,9 @@
 import { getConfig, getArchiveBoxServerUrl } from './storage';
 import { t } from './i18n';
-import { archiveBoxServerUrlMatches } from './archiveboxUrlExclusions';
+import { archiveBoxServerUrlMatches, isArchiveablePageUrl } from './archiveboxUrlExclusions';
 import type { ArchiveBoxAddResult, ArchiveDepth, Snapshot } from './types';
 
-export { archiveBoxServerUrlMatches } from './archiveboxUrlExclusions';
+export { archiveBoxServerUrlMatches, isArchiveablePageUrl } from './archiveboxUrlExclusions';
 
 export type ArchiveResultUploadFile = {
   blob: Blob;

--- a/src/lib/archiveboxUrlExclusions.ts
+++ b/src/lib/archiveboxUrlExclusions.ts
@@ -26,16 +26,16 @@ function hostnameMatchesDomain(hostname: string, domain: string): boolean {
   return hostname === domain || hostname.endsWith(`.${domain}`);
 }
 
-// Pages the extension can actually fetch, screenshot, or capture as MHTML.
-// Everything else (about:blank, chrome://, chrome-extension://, devtools://,
-// data:, view-source:, the new tab page, etc.) is not capturable, so trying to
-// archive it only produces "Cannot find the tab"/"Don't have permissions"
-// errors and saves junk snapshots.
+// Pages the extension should archive: only real http(s) web pages. Everything
+// else (file://, about:blank, chrome://, chrome-extension://, devtools://,
+// data:, view-source:, the new tab page, etc.) is either local/private or not
+// capturable, so trying to archive it only produces "Cannot find the tab"/"Don't
+// have permissions" errors and saves junk snapshots.
 export function isArchiveablePageUrl(targetUrl: string): boolean {
   if (!targetUrl) return false;
   try {
     const { protocol } = new URL(targetUrl);
-    return protocol === 'http:' || protocol === 'https:' || protocol === 'file:';
+    return protocol === 'http:' || protocol === 'https:';
   } catch {
     return false;
   }

--- a/src/lib/archiveboxUrlExclusions.ts
+++ b/src/lib/archiveboxUrlExclusions.ts
@@ -26,6 +26,21 @@ function hostnameMatchesDomain(hostname: string, domain: string): boolean {
   return hostname === domain || hostname.endsWith(`.${domain}`);
 }
 
+// Pages the extension can actually fetch, screenshot, or capture as MHTML.
+// Everything else (about:blank, chrome://, chrome-extension://, devtools://,
+// data:, view-source:, the new tab page, etc.) is not capturable, so trying to
+// archive it only produces "Cannot find the tab"/"Don't have permissions"
+// errors and saves junk snapshots.
+export function isArchiveablePageUrl(targetUrl: string): boolean {
+  if (!targetUrl) return false;
+  try {
+    const { protocol } = new URL(targetUrl);
+    return protocol === 'http:' || protocol === 'https:' || protocol === 'file:';
+  } catch {
+    return false;
+  }
+}
+
 export function archiveBoxServerUrlMatches(serverUrl: string, targetUrl: string): boolean {
   if (!serverUrl || !targetUrl) return false;
 

--- a/tests/popup.test.ts
+++ b/tests/popup.test.ts
@@ -1020,7 +1020,14 @@ test('the injected page content script contains no popup or window-closing code'
     path.join(builtExtensionPath, 'content-scripts/archivebox.js'),
     'utf8',
   );
+  // Regression guard for the 3.0.1 tab-closing bug: that content script's
+  // runtime.onMessage listener called a bare `close()` for 'hide_archivebox_overlay',
+  // which resolves to the global window.close() in the page context and closed
+  // the user's tab. The in-page content script must never call close() in any
+  // form -- not window.close, not self.close, and not a bare close().
   expect(contentScript).not.toMatch(/window\.close/);
+  expect(contentScript).not.toMatch(/self\.close/);
+  expect(contentScript).not.toMatch(/(^|[^.\w])close\s*\(/);
   expect(contentScript).not.toContain('archivebox-overlay');
   expect(contentScript).not.toContain('opened save panel');
 

--- a/tests/popup.test.ts
+++ b/tests/popup.test.ts
@@ -48,6 +48,7 @@ type CdpClient = {
     predicate: (event: CdpEvent<T>) => boolean,
     timeoutMs?: number,
   ): Promise<CdpEvent<T>>;
+  on<T = Record<string, unknown>>(method: string, handler: (event: CdpEvent<T>) => void): () => void;
   close(): void;
 };
 
@@ -89,6 +90,8 @@ const chromeProfileBasePath = path.resolve('tmp/chrome_profile');
 const shortDelay = 50;
 
 function selectedBrowserExecutable(): string {
+  const override = process.env.CHROME_FOR_TESTING_BIN || process.env.CHROME_BIN;
+  if (override && existsSync(override)) return override;
   if (existsSync('/usr/bin/chromium')) return '/usr/bin/chromium';
   if (existsSync(canaryPath)) return canaryPath;
   return chromium.executablePath();
@@ -147,6 +150,7 @@ async function connectCdpWebSocket(webSocketDebuggerUrl: string): Promise<CdpCli
     timeout: ReturnType<typeof setTimeout>;
   }>();
   const recentEvents: string[] = [];
+  const eventListeners = new Map<string, Set<(event: CdpEvent) => void>>();
 
   socket.addEventListener('message', (event) => {
     const message = JSON.parse(String(event.data));
@@ -164,6 +168,9 @@ async function connectCdpWebSocket(webSocketDebuggerUrl: string): Promise<CdpCli
         clearTimeout(waiter.timeout);
         eventWaiters.delete(waiter);
         waiter.resolve(cdpEvent);
+      }
+      for (const handler of eventListeners.get(message.method) || []) {
+        handler(cdpEvent);
       }
       return;
     }
@@ -224,6 +231,14 @@ async function connectCdpWebSocket(webSocketDebuggerUrl: string): Promise<CdpCli
         };
         eventWaiters.add(waiter);
       });
+    },
+    on<T = Record<string, unknown>>(method: string, handler: (event: CdpEvent<T>) => void) {
+      const listeners = eventListeners.get(method) || new Set<(event: CdpEvent) => void>();
+      listeners.add(handler as (event: CdpEvent) => void);
+      eventListeners.set(method, listeners);
+      return () => {
+        eventListeners.get(method)?.delete(handler as (event: CdpEvent) => void);
+      };
     },
     close() {
       socket.close();
@@ -322,6 +337,46 @@ async function startFixtureServer(): Promise<FixtureServer> {
   return { server, url: `http://127.0.0.1:${address.port}/` };
 }
 
+function spawnBrowser(
+  executablePath: string,
+  userDataDir: string,
+  remoteDebuggingPort: number,
+  extraArgs: string[],
+): ChildProcess {
+  const headlessLinux = process.platform === 'linux' && !process.env.DISPLAY;
+  const args = [
+    `--user-data-dir=${userDataDir}`,
+    `--remote-debugging-port=${remoteDebuggingPort}`,
+    // Chrome 149+ exposes the CDP Extensions domain (Extensions.loadUnpacked)
+    // only when extension debugging is explicitly enabled over the connection.
+    '--enable-unsafe-extension-debugging',
+    '--no-first-run',
+    '--no-default-browser-check',
+    '--disable-background-networking',
+    ...extraArgs,
+    'about:blank',
+  ];
+  if (headlessLinux) {
+    args.splice(args.length - 1, 0, '--headless=new', '--no-sandbox');
+  }
+  return spawn(executablePath, args, { stdio: 'ignore' });
+}
+
+async function waitForLoadedExtensionId(remoteDebuggingPort: number, timeoutMs = 15_000): Promise<string> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    const targets = await waitForJson<DevToolsTarget[]>(`http://127.0.0.1:${remoteDebuggingPort}/json/list`);
+    const worker = targets.find((target) => (
+      (target.type === 'service_worker' || target.type === 'background_page')
+      && /^chrome-extension:\/\/[a-p]{32}\/background\.js/.test(target.url)
+    ));
+    const match = worker?.url.match(/^chrome-extension:\/\/([a-p]{32})\//);
+    if (match?.[1]) return match[1];
+    await sleep();
+  }
+  throw new Error('Timed out waiting for the extension service worker to register');
+}
+
 async function launchHarness(): Promise<BrowserHarness> {
   const runId = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
   const extensionPath = await prepareTestExtensionPath(path.join(testExtensionBasePath, runId));
@@ -330,39 +385,57 @@ async function launchHarness(): Promise<BrowserHarness> {
   const userDataDir = path.join(chromeProfileBasePath, runId);
   await rm(userDataDir, { recursive: true, force: true });
   await mkdir(userDataDir, { recursive: true });
-  const headlessLinux = process.platform === 'linux' && !process.env.DISPLAY;
-  const args = [
-    `--user-data-dir=${userDataDir}`,
-    `--remote-debugging-port=${remoteDebuggingPort}`,
-    '--no-first-run',
-    '--no-default-browser-check',
-    '--disable-background-networking',
-    'about:blank',
-  ];
-  if (headlessLinux) {
-    args.splice(args.length - 1, 0, '--headless=new', '--no-sandbox');
+
+  let activeUserDataDir = userDataDir;
+  let browserProcess = spawnBrowser(executablePath, activeUserDataDir, remoteDebuggingPort, []);
+  await waitForJson(`http://127.0.0.1:${remoteDebuggingPort}/json/version`);
+  let cdp = await connectBrowserCdp(remoteDebuggingPort);
+
+  let extensionId: string;
+  try {
+    const loaded = await cdp.send<{ id: string }>('Extensions.loadUnpacked', { path: extensionPath });
+    extensionId = loaded.id;
+  } catch (error) {
+    if (!/method not available|not found|extensions/i.test(error instanceof Error ? error.message : String(error))) {
+      throw error;
+    }
+    // Chrome <149 does not expose the CDP Extensions domain over the websocket
+    // endpoint, so fall back to the --load-extension launch flag it still
+    // supports and discover the generated extension ID from its service worker.
+    // Relaunch into a fresh profile dir (rather than wiping and reusing the
+    // first one, which races with the just-killed browser releasing the dir).
+    cdp.close();
+    browserProcess.kill('SIGTERM');
+    await waitForProcessExit(browserProcess);
+    const firstUserDataDir = activeUserDataDir;
+    activeUserDataDir = `${userDataDir}-loadext`;
+    await mkdir(activeUserDataDir, { recursive: true });
+    browserProcess = spawnBrowser(executablePath, activeUserDataDir, remoteDebuggingPort, [
+      `--disable-extensions-except=${extensionPath}`,
+      `--load-extension=${extensionPath}`,
+    ]);
+    await waitForJson(`http://127.0.0.1:${remoteDebuggingPort}/json/version`);
+    extensionId = await waitForLoadedExtensionId(remoteDebuggingPort);
+    cdp = await connectBrowserCdp(remoteDebuggingPort);
+    await rm(firstUserDataDir, { recursive: true, force: true }).catch(() => undefined);
   }
 
-  const browserProcess = spawn(executablePath, args, { stdio: 'ignore' });
-  await waitForJson(`http://127.0.0.1:${remoteDebuggingPort}/json/version`);
-  const cdp = await connectBrowserCdp(remoteDebuggingPort);
-  const loaded = await cdp.send<{ id: string }>('Extensions.loadUnpacked', { path: extensionPath });
   const browser = await chromium.connectOverCDP(`http://127.0.0.1:${remoteDebuggingPort}`);
   const context = browser.contexts()[0];
   if (!context) throw new Error('Playwright did not expose the CDP browser context');
   const storagePage = await context.newPage();
-  await storagePage.goto(`chrome-extension://${loaded.id}/options.html`, { waitUntil: 'domcontentloaded' });
+  await storagePage.goto(`chrome-extension://${extensionId}/options.html`, { waitUntil: 'domcontentloaded' });
 
   return {
     browser,
     context,
     cdp,
     extensionPath,
-    extensionId: loaded.id,
+    extensionId,
     process: browserProcess,
     remoteDebuggingPort,
     storagePage,
-    userDataDir,
+    userDataDir: activeUserDataDir,
   };
 }
 
@@ -437,6 +510,103 @@ async function extensionHasPermission(harness: BrowserHarness, permission: strin
       extensionApi.permissions.contains({ permissions: [permissionName as Browser.runtime.ManifestPermission] }, resolve);
     });
   }, permission);
+}
+
+type ConsoleMessage = {
+  source: string;
+  type: string;
+  text: string;
+};
+
+type ConsoleCollector = {
+  messages: ConsoleMessage[];
+  errors: () => ConsoleMessage[];
+  close: () => void;
+};
+
+function remoteObjectText(arg: { value?: unknown; description?: string; unserializableValue?: string }): string {
+  if (arg.value !== undefined) return typeof arg.value === 'string' ? arg.value : JSON.stringify(arg.value);
+  if (arg.description) return arg.description;
+  if (arg.unserializableValue) return arg.unserializableValue;
+  return '';
+}
+
+async function attachConsoleCollector(cdp: CdpClient, source: string, messages: ConsoleMessage[]): Promise<void> {
+  cdp.on<{ type: string; args?: Array<{ value?: unknown; description?: string }> }>('Runtime.consoleAPICalled', (event) => {
+    const text = (event.params.args || []).map(remoteObjectText).join(' ');
+    messages.push({ source, type: event.params.type, text });
+  });
+  cdp.on<{ exceptionDetails?: { text?: string; exception?: { description?: string } } }>('Runtime.exceptionThrown', (event) => {
+    const details = event.params.exceptionDetails;
+    messages.push({
+      source,
+      type: 'error',
+      text: details?.exception?.description || details?.text || 'Uncaught exception',
+    });
+  });
+  cdp.on<{ entry: { level: string; text: string } }>('Log.entryAdded', (event) => {
+    messages.push({ source, type: event.params.entry.level, text: event.params.entry.text });
+  });
+  await cdp.send('Runtime.enable');
+  await cdp.send('Log.enable');
+}
+
+async function findDevToolsTarget(
+  harness: BrowserHarness,
+  predicate: (target: DevToolsTarget) => boolean,
+  timeoutMs = 15_000,
+): Promise<DevToolsTarget> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    const targets = await waitForJson<DevToolsTarget[]>(`http://127.0.0.1:${harness.remoteDebuggingPort}/json/list`);
+    const target = targets.find((item) => predicate(item) && item.webSocketDebuggerUrl);
+    if (target) return target;
+    await sleep();
+  }
+  throw new Error('Timed out waiting for DevTools target');
+}
+
+async function collectBackgroundConsole(harness: BrowserHarness, messages: ConsoleMessage[]): Promise<ConsoleCollector> {
+  const target = await findDevToolsTarget(harness, (item) => (
+    item.type === 'service_worker' && /\/background\.js/.test(item.url)
+  ));
+  const cdp = await connectCdpWebSocket(target.webSocketDebuggerUrl as string);
+  await attachConsoleCollector(cdp, 'background', messages);
+  return {
+    messages,
+    errors: () => messages.filter((message) => message.type === 'error'),
+    close: () => cdp.close(),
+  };
+}
+
+async function pageTargetExists(harness: BrowserHarness, url: string): Promise<boolean> {
+  const { targetInfos } = await harness.cdp.send<{ targetInfos: CdpTarget[] }>('Target.getTargets', { filter: [{}] });
+  return targetInfos.some((target) => (
+    (target.type === 'page' || target.type === 'tab') && target.url.startsWith(url)
+  ));
+}
+
+// Console errors/warnings that ArchiveBox itself produced, ignoring noise the
+// fixture page generates on its own (e.g. its missing /favicon.ico).
+function archiveboxConsoleProblems(messages: ConsoleMessage[]): ConsoleMessage[] {
+  return messages.filter((message) => {
+    if (message.type !== 'error' && message.type !== 'warning') return false;
+    if (message.source === 'page' && /Failed to load resource/i.test(message.text)) return false;
+    return true;
+  });
+}
+
+function consoleMessagesMatching(messages: ConsoleMessage[], pattern: RegExp): ConsoleMessage[] {
+  return messages.filter((message) => pattern.test(message.text));
+}
+
+async function waitForConsoleMessage(messages: ConsoleMessage[], pattern: RegExp, timeoutMs = 15_000): Promise<void> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    if (consoleMessagesMatching(messages, pattern).length > 0) return;
+    await sleep();
+  }
+  throw new Error(`Timed out waiting for console message matching ${pattern}`);
 }
 
 async function waitForTabTarget(cdp: CdpClient, url: string): Promise<CdpTarget> {
@@ -840,6 +1010,28 @@ async function waitForNoSavedEntry(harness: BrowserHarness, url: string, timeout
   throw new Error(`Timed out waiting for saved entry removal: ${url}`);
 }
 
+test('the injected page content script contains no popup or window-closing code', async () => {
+  // The overlay/popup UI (which legitimately calls window.close() on its own
+  // popup window) must never be bundled into the content script that gets
+  // injected into the pages the user is viewing -- otherwise window.close()
+  // would run in the page context and close the user's tab. This guards against
+  // a regression where popup code leaks into the in-page content script.
+  const contentScript = await readFile(
+    path.join(builtExtensionPath, 'content-scripts/archivebox.js'),
+    'utf8',
+  );
+  expect(contentScript).not.toMatch(/window\.close/);
+  expect(contentScript).not.toContain('archivebox-overlay');
+  expect(contentScript).not.toContain('opened save panel');
+
+  const manifest = JSON.parse(
+    await readFile(path.join(builtExtensionPath, 'manifest.json'), 'utf8'),
+  ) as { content_scripts?: unknown[] };
+  // The extension injects its content script on demand via scripting.executeScript,
+  // so it should declare no statically-registered content scripts.
+  expect(manifest.content_scripts ?? []).toEqual([]);
+});
+
 test('ArchiveBox server URLs are ignored before archive requests', async () => {
   const harness = await launchHarness();
 
@@ -1173,6 +1365,130 @@ test('native action popup supports local save, tags, depth, captures, navigation
     await waitForNoNativePopup(harness);
     entries = await savedEntries(harness);
     expect(entries.some((entry) => entry.url === testPageUrl)).toBe(false);
+  } finally {
+    await closeHarness(harness);
+    await new Promise<void>((resolve) => server.server.close(() => resolve()));
+  }
+});
+
+test('auto-archive captures MHTML + screenshots on page load without console errors or closing the tab', async () => {
+  test.setTimeout(60_000);
+  const server = await startFixtureServer();
+  const harness = await launchHarness();
+  const messages: ConsoleMessage[] = [];
+
+  try {
+    // Real local capture (no archivebox_test_fast_capture) so this exercises the
+    // genuine pageCapture.saveAsMHTML + captureVisibleTab paths the user hits.
+    await setExtensionStorage(harness, {
+      entries: [],
+      archivebox_server_url: '',
+      archivebox_api_key: '',
+      save_mhtml_locally: true,
+      save_screenshots_locally: true,
+      enable_auto_archive: true,
+      match_urls: '.*',
+    });
+    const background = await collectBackgroundConsole(harness, messages);
+    // give storage.onChanged time to register the auto-archive tab listener
+    await sleep(500);
+
+    const page = await harness.context.newPage();
+    page.on('console', (message) => messages.push({ source: 'page', type: message.type(), text: message.text() }));
+    page.on('pageerror', (error) => messages.push({ source: 'page', type: 'error', text: error.message }));
+    const testPageUrl = `${server.url}?archivebox_test=1`;
+    await page.goto(testPageUrl, { waitUntil: 'load' });
+
+    // A blank/new tab must never be archived: it is not capturable and only
+    // produces permission errors and junk snapshots.
+    await harness.context.newPage();
+
+    const entry = await waitForSavedEntry(
+      harness,
+      testPageUrl,
+      (saved) => Boolean(saved.mhtml) && Boolean(saved.screenshot),
+      'auto-archived MHTML + screenshot',
+      20_000,
+    );
+    expect(entry.tags).toContain('auto-archived');
+
+    // The user's tab must still be open after capture finishes.
+    expect(await pageTargetExists(harness, testPageUrl)).toBe(true);
+
+    const entries = await savedEntries(harness);
+    expect(entries.some((saved) => saved.url === 'about:blank')).toBe(false);
+    expect(entries.every((saved) => /^(https?|file):/i.test(String(saved.url)))).toBe(true);
+
+    // Expected milestone log lines (action + saved artifacts + remote result).
+    await waitForConsoleMessage(messages, /ArchiveBox: auto-archiving/);
+    await waitForConsoleMessage(messages, /ArchiveBox: saved MHTML for/);
+    await waitForConsoleMessage(messages, /ArchiveBox: saved screenshot for/);
+    await waitForConsoleMessage(messages, /no ArchiveBox server configured/);
+
+    // No "Scripts may close..." attempt from any injected script.
+    expect(consoleMessagesMatching(messages, /scripts may close/i)).toEqual([]);
+    // No console errors/warnings produced by ArchiveBox itself.
+    expect(archiveboxConsoleProblems(messages)).toEqual([]);
+    // The popup/overlay UI must never execute inside the page the user views.
+    expect(await page.locator('.archivebox-overlay').count()).toBe(0);
+    expect(messages.filter((message) => (
+      message.source === 'page' && /opened save panel|archivebox-overlay/i.test(message.text)
+    ))).toEqual([]);
+
+    background.close();
+  } finally {
+    await closeHarness(harness);
+    await new Promise<void>((resolve) => server.server.close(() => resolve()));
+  }
+});
+
+test('action popup saves MHTML + screenshots without console errors or closing the active tab', async () => {
+  test.setTimeout(60_000);
+  const server = await startFixtureServer();
+  const harness = await launchHarness();
+  const messages: ConsoleMessage[] = [];
+
+  try {
+    await setExtensionStorage(harness, {
+      entries: [],
+      archivebox_server_url: '',
+      archivebox_api_key: '',
+      save_mhtml_locally: true,
+      save_screenshots_locally: true,
+    });
+    const background = await collectBackgroundConsole(harness, messages);
+
+    const page = await harness.context.newPage();
+    page.on('console', (message) => messages.push({ source: 'page', type: message.type(), text: message.text() }));
+    page.on('pageerror', (error) => messages.push({ source: 'page', type: 'error', text: error.message }));
+    const testPageUrl = `${server.url}?archivebox_test=1`;
+    await page.goto(testPageUrl, { waitUntil: 'load' });
+
+    const popup = await openNativePopup(harness, page);
+    await attachConsoleCollector(popup.cdp, 'popup', messages);
+    await waitForPopupText(harness, popup, testPageUrl);
+
+    await clickPopupButtonText(harness, popup, 'MHTML');
+    await waitForSavedEntry(harness, testPageUrl, (saved) => Boolean(saved.mhtml), 'popup MHTML', 15_000);
+
+    await clickPopupButtonText(harness, popup, 'Screenshot');
+    await waitForSavedEntry(harness, testPageUrl, (saved) => Boolean(saved.screenshot), 'popup screenshot', 20_000);
+
+    // The page the user was viewing must still be open.
+    expect(await pageTargetExists(harness, testPageUrl)).toBe(true);
+
+    await waitForConsoleMessage(messages, /ArchiveBox: saved MHTML for/);
+    await waitForConsoleMessage(messages, /ArchiveBox: saved screenshot for/);
+
+    expect(consoleMessagesMatching(messages, /scripts may close/i)).toEqual([]);
+    expect(archiveboxConsoleProblems(messages)).toEqual([]);
+    // The popup/overlay UI runs only in the popup window, never in the page.
+    expect(await page.locator('.archivebox-overlay').count()).toBe(0);
+    expect(messages.filter((message) => (
+      message.source === 'page' && /opened save panel|archivebox-overlay/i.test(message.text)
+    ))).toEqual([]);
+
+    background.close();
   } finally {
     await closeHarness(harness);
     await new Promise<void>((resolve) => server.server.close(() => resolve()));

--- a/tests/popup.test.ts
+++ b/tests/popup.test.ts
@@ -1029,7 +1029,6 @@ test('the injected page content script contains no popup or window-closing code'
   expect(contentScript).not.toMatch(/self\.close/);
   expect(contentScript).not.toMatch(/(^|[^.\w])close\s*\(/);
   expect(contentScript).not.toContain('archivebox-overlay');
-  expect(contentScript).not.toContain('opened save panel');
 
   const manifest = JSON.parse(
     await readFile(path.join(builtExtensionPath, 'manifest.json'), 'utf8'),
@@ -1439,7 +1438,7 @@ test('auto-archive captures MHTML + screenshots on page load without console err
     // The popup/overlay UI must never execute inside the page the user views.
     expect(await page.locator('.archivebox-overlay').count()).toBe(0);
     expect(messages.filter((message) => (
-      message.source === 'page' && /opened save panel|archivebox-overlay/i.test(message.text)
+      message.source === 'page' && /archivebox-overlay/i.test(message.text)
     ))).toEqual([]);
 
     background.close();
@@ -1492,7 +1491,7 @@ test('action popup saves MHTML + screenshots without console errors or closing t
     // The popup/overlay UI runs only in the popup window, never in the page.
     expect(await page.locator('.archivebox-overlay').count()).toBe(0);
     expect(messages.filter((message) => (
-      message.source === 'page' && /opened save panel|archivebox-overlay/i.test(message.text)
+      message.source === 'page' && /archivebox-overlay/i.test(message.text)
     ))).toEqual([]);
 
     background.close();

--- a/tests/popup.test.ts
+++ b/tests/popup.test.ts
@@ -1423,7 +1423,7 @@ test('auto-archive captures MHTML + screenshots on page load without console err
 
     const entries = await savedEntries(harness);
     expect(entries.some((saved) => saved.url === 'about:blank')).toBe(false);
-    expect(entries.every((saved) => /^(https?|file):/i.test(String(saved.url)))).toBe(true);
+    expect(entries.every((saved) => /^https?:/i.test(String(saved.url)))).toBe(true);
 
     // Expected milestone log lines (action + saved artifacts + remote result).
     await waitForConsoleMessage(messages, /ArchiveBox: auto-archiving/);


### PR DESCRIPTION
## Summary

This PR fixes some race conditions around mhtml capture.

## Key Changes

### Bug Fixes

- **Add test for content script isolation**: New test verifies that the content script contains no popup UI code or window-closing calls
- **Validate archiveable URLs**: Added `isArchiveablePageUrl()` function to prevent attempting to capture non-archiveable pages (about:blank, chrome://, data:, etc.) which produce permission errors and junk snapshots

### Capture Reliability Improvements

- **MHTML capture retry logic**: Implemented retry mechanism (up to 3 attempts) for transient MHTML read failures caused by Chromium's temp file cleanup race condition
- **Tab validation before capture**: Re-check that tabs are still available and on archiveable URLs immediately before MHTML/screenshot capture, preventing "Cannot find the tab" errors
- **Serialized MHTML captures**: Queue MHTML captures to prevent concurrent operations from interfering with each other's blob handles
- **Better error classification**: Distinguish between transient read errors (retryable) and permanent errors (permission, missing tab)

### Browser Compatibility
- **Chrome 149+ support**: Added `--enable-unsafe-extension-debugging` flag and fallback logic for older Chrome versions that don't expose the CDP Extensions domain
- **Graceful degradation**: When `Extensions.loadUnpacked` is unavailable, fall back to `--load-extension` launch flag and discover extension ID from service worker

### Testing & Logging
- **Console logging**: Added informative console messages for capture milestones (auto-archiving, saved MHTML, saved screenshots, server sync status)
- **New integration tests**: Added comprehensive tests for auto-archive and popup save operations that verify:
  - MHTML + screenshot capture without console errors
  - User's tab remains open after capture
  - No popup UI leaks into page context
  - Proper handling of non-capturable pages (about:blank)
- **Console collection utilities**: New helper functions to collect and filter console messages from background, popup, and page contexts for test assertions

### Infrastructure
- **CDP client enhancements**: Added `on()` method to CDP client for event listener registration with cleanup
- **Browser executable selection**: Support `CHROME_FOR_TESTING_BIN` and `CHROME_BIN` environment variables for test runner flexibility
- **Helper functions**: New utilities for finding DevTools targets, waiting for extension load, and collecting console output

## Notable Implementation Details
- MHTML capture failures are retried only for transient read errors (blob file deletion), not for permission or tab availability issues
- Auto-archive and manual saves now use a unified `syncSnapshotToServer()` function that logs results without throwing
- The extension properly handles both modern (CDP Extensions domain) and legacy (--load-extension) Chrome versions
- All capture operations validate the target URL and tab state to prevent errors and junk snapshots

https://claude.ai/code/session_01UMvsfQyTMWQGo53Azn1KHT

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug that could close the active tab during capture and makes MHTML/screenshot capture more reliable. Only archives real web pages (http/https), adds serialized MHTML retries, URL-stability checks, cleaner milestone logs, broader Chrome support, and end-to-end tests.

- Bug Fixes
  - Keep popup/overlay code out of the content script; add a regression test blocking window.close/self.close/bare close() and ensuring no static content scripts.
  - Only archive http/https URLs via `isArchiveablePageUrl()` across auto-archive, save, and the popup’s active-page detection; re-check that the tab is present, complete, capturable, and still on the same URL as the snapshot right before MHTML capture (and between retries).

- Capture Reliability, Logging, and Compatibility
  - Retry MHTML up to 3 times on transient blob-read errors and serialize captures; retry only on transient errors.
  - Milestone logs: auto-archiving start, saved MHTML/screenshot/SingleFile, and server sync result; treat “no server configured” as normal and unify server sync in non-throwing `syncSnapshotToServer()`; drop the popup “opened save panel” log.
  - Chrome support: enable CDP Extensions on 149+ and fall back to `--load-extension` on older versions; allow `CHROME_FOR_TESTING_BIN`/`CHROME_BIN`.
  - Tests: new e2e for auto-archive and popup verifying artifacts save, the tab stays open, no overlay leaks into pages, and no ArchiveBox console errors; add console collectors and a CDP `on()` helper.

<sup>Written for commit 8b96a00b6f414d116ceb21eb122c9783a062caeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ArchiveBox/archivebox-browser-extension/pull/54?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

